### PR TITLE
Enable VirtualThread natives by default

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -991,7 +991,8 @@ final class VirtualThread extends BaseVirtualThread {
 
     // -- JVM TI support --
 
-    private static volatile boolean notifyJvmtiEvents;  // set by VM
+    // will always be true because a JVM TI agent can be attached at any time
+    private static volatile boolean notifyJvmtiEvents = true;
 
     @JvmtiMountTransition
     private native void notifyJvmtiMountBegin(boolean firstMount);


### PR DESCRIPTION
The VirtualThread natives are needed to keep a list of every live virtual
thread for JVM TI. Since JVM TI agents can be attached at any time, enable
these natives by default.

Issue: eclipse-openj9/openj9#15183
Signed-off-by: Eric Yang <eric.yang@ibm.com>