### PR TITLE
AArch64: Enable FFI upcall

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -164,7 +164,7 @@ public abstract class CallArranger {
 
     /* Replace UpcallLinker in OpenJDK with the implementation of UpcallLinker specific to OpenJ9 */
     public static MemorySegment arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc, MemorySession session) {
-        throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+        return UpcallLinker.make(target, mt, cDesc, session);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {


### PR DESCRIPTION
This commit enables FFI upcall on AArch64 Linux/macOS.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>