### PR TITLE
[JEP424] Implement VaList on Power (Linux & AIX) in JDK19

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/TypeClass.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryAddress;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
+import static java.lang.foreign.ValueLayout.*;
+import java.lang.invoke.VarHandle;
+
+/**
+ * This class enumerates three argument types for Linux/ppc64le against the implementation
+ * of TypeClass on x64/windows as the template.
+ */
+public enum TypeClass {
+	PRIMITIVE, /* Intended for all primitive types */
+	POINTER,
+	STRUCT;
+
+	public static VarHandle classifyVarHandle(ValueLayout layout) {
+		VarHandle argHandle = null;
+		Class<?> carrier = layout.carrier();
+
+		/* According to the API Spec, all non-long integral types are promoted to long
+		 * while a float is promoted to double.
+		 */
+		if ((carrier == boolean.class)
+			|| (carrier == byte.class)
+			|| (carrier == char.class)
+			|| (carrier == short.class)
+			|| (carrier == int.class)
+		) {
+			argHandle = JAVA_LONG.varHandle();
+		} else if (carrier == float.class) {
+			argHandle = JAVA_DOUBLE.varHandle();
+		} else if ((carrier == long.class)
+			|| (carrier == double.class)
+			|| (carrier == MemoryAddress.class)
+		) {
+			argHandle = layout.varHandle();
+		} else {
+			throw new IllegalStateException("Unspported carrier: " + carrier.getName());
+		}
+
+		return argHandle;
+	}
+
+	public static TypeClass classifyLayout(MemoryLayout layout) {
+		TypeClass layoutType = null;
+
+		if (layout instanceof ValueLayout) {
+			layoutType = classifyValueType((ValueLayout)layout);
+		} else if (layout instanceof GroupLayout) {
+			layoutType = STRUCT;
+		} else {
+			throw new IllegalArgumentException("Unsupported layout: " + layout);
+		}
+
+		return layoutType;
+	}
+
+	private static TypeClass classifyValueType(ValueLayout layout) {
+		TypeClass layoutType = null;
+		Class<?> carrier = layout.carrier();
+
+		if ((carrier == boolean.class)
+			|| (carrier == byte.class)
+			|| (carrier == char.class)
+			|| (carrier == short.class)
+			|| (carrier == int.class)
+			|| (carrier == long.class)
+			|| (carrier == float.class)
+			|| (carrier == double.class)
+		) {
+			layoutType = PRIMITIVE;
+		} else if (carrier == MemoryAddress.class) {
+			layoutType = POINTER;
+		} else {
+			throw new IllegalStateException("Unspported carrier: " + carrier.getName());
+		}
+
+		return layoutType;
+	}
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64VaList.java
@@ -33,123 +33,246 @@
 package jdk.internal.foreign.abi.ppc64.aix;
 
 import java.lang.foreign.*;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
+import jdk.internal.foreign.abi.ppc64.TypeClass;
+import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.Scoped;
-import jdk.internal.foreign.Utils;
-import jdk.internal.foreign.abi.SharedUtils;
 import static jdk.internal.foreign.PlatformLayouts.AIX;
 
 /**
- * This file serves as a placeholder for VaList on AIX/ppc64 as the code
- * at Java level is not yet implemented for the moment. Futher analysis on
- * the struct is required to understand how the struct is laid out in memory
- * according to the description in the publisized ABI document at
- * https://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.pdf.
+ * This class implements VaList specific to AIX/ppc64 based on the publisized ABI document at
+ * https://www.ibm.com/docs/en/ssw_aix_72/pdf/assembler_pdf.pdf against the code of VaList on
+ * x64/windows as the template.
+ *
+ * va_arg impl on AIX/ppc64:
+ * typedef void * va_list;
+ *
+ * Specifically, va_list is simply a pointer (similar to the va_list on x64/windows) to a buffer
+ * with all supportted types of arugments, including struct (passed by value), pointer and
+ * primitive types, which are aligned with 8 bytes.
  */
 public non-sealed class AixPPC64VaList implements VaList, Scoped {
-    static final Class<?> CARRIER = MemoryAddress.class;
+	public static final Class<?> CARRIER = MemoryAddress.class;
 
-    public static VaList empty() {
-        throw new InternalError("empty() is not yet implemented"); //$NON-NLS-1$
-    }
+	/* Every primitive/pointer occupies 8 bytes and structs are aligned
+	 * with 8 bytes in the total size when stacking the va_list buffer.
+	 */
+	private static final long VA_LIST_SLOT_BYTES = 8;
+	private static final VaList EMPTY = new SharedUtils.EmptyVaList(MemoryAddress.NULL);
 
-    @Override
-    public int nextVarg(ValueLayout.OfInt layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	private MemorySegment segment;
+	private final MemorySession session;
 
-    @Override
-    public long nextVarg(ValueLayout.OfLong layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	private AixPPC64VaList(MemorySegment segment, MemorySession session) {
+		this.segment = segment;
+		this.session = session;
+	}
 
-    @Override
-    public double nextVarg(ValueLayout.OfDouble layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	public static final VaList empty() {
+		return EMPTY;
+	}
 
-    @Override
-    public MemoryAddress nextVarg(ValueLayout.OfAddress layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public int nextVarg(ValueLayout.OfInt layout) {
+		return Math.toIntExact((long)readArg(layout));
+	}
 
-    @Override
-    public MemorySegment nextVarg(GroupLayout layout, SegmentAllocator allocator) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public long nextVarg(ValueLayout.OfLong layout) {
+		return (long)readArg(layout);
+	}
 
-    @Override
-    public void skip(MemoryLayout... layouts) {
-        throw new InternalError("skip() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public double nextVarg(ValueLayout.OfDouble layout) {
+		return (double)readArg(layout);
+	}
 
-    public static VaList ofAddress(MemoryAddress ma, MemorySession session) {
-        throw new InternalError("ofAddress() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public MemoryAddress nextVarg(ValueLayout.OfAddress layout) {
+		return (MemoryAddress)readArg(layout);
+	}
 
-    @Override
-    public MemorySession session() {
-        throw new InternalError("session() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public MemorySegment nextVarg(GroupLayout layout, SegmentAllocator allocator) {
+		return (MemorySegment)readArg(layout, allocator);
+	}
 
-    @Override
-    public MemorySessionImpl sessionImpl() {
-        return MemorySessionImpl.toSessionImpl(session());
-    }
+	private Object readArg(MemoryLayout argLayout) {
+		return readArg(argLayout, SharedUtils.THROWING_ALLOCATOR);
+	}
 
-    @Override
-    public VaList copy() {
-        throw new InternalError("copy() is not yet implemented"); //$NON-NLS-1$
-    }
+	private Object readArg(MemoryLayout argLayout, SegmentAllocator allocator) {
+		Objects.requireNonNull(argLayout);
+		Objects.requireNonNull(allocator);
+		Object argument = null;
 
-    @Override
-    public MemoryAddress address() {
-        throw new InternalError("address() is not yet implemented"); //$NON-NLS-1$
-    }
+		TypeClass typeClass = TypeClass.classifyLayout(argLayout);
+		long argByteSize = getAlignedArgSize(argLayout);
+		checkNextArgument(argLayout, argByteSize);
 
-    @Override
-    public String toString() {
-        throw new InternalError("toString() is not yet implemented"); //$NON-NLS-1$
-    }
+		switch (typeClass) {
+			case PRIMITIVE, POINTER -> {
+				VarHandle argHandle = TypeClass.classifyVarHandle((ValueLayout)argLayout);
+				argument = argHandle.get(segment);
+			}
+			case STRUCT -> {
+				/* Copy the struct argument with the aligned size from the va_list buffer to allocated memory */
+				argument = allocator.allocate(argByteSize).copyFrom(segment.asSlice(0, argByteSize));
+			}
+			default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
+		}
 
-    static AixPPC64VaList.Builder builder(MemorySession session) {
-        return new AixPPC64VaList.Builder(session);
-    }
+		/* Move to the next argument in the va_list buffer */
+		segment = segment.asSlice(argByteSize);
+		return argument;
+	}
 
-    public static non-sealed class Builder implements VaList.Builder {
+	private static long getAlignedArgSize(MemoryLayout argLayout) {
+		long argLayoutSize = VA_LIST_SLOT_BYTES; // Always aligned with 8 bytes for primitives/pointer by default
 
-        public Builder(MemorySession session) {
-            throw new InternalError("Builder() is not yet implemented"); //$NON-NLS-1$
-        }
+		/* As with primitives, a struct should aligned with 8 bytes */
+		if (argLayout instanceof GroupLayout) {
+			argLayoutSize = argLayout.byteSize();
+			if ((argLayoutSize % VA_LIST_SLOT_BYTES) > 0) {
+				argLayoutSize = (argLayoutSize / VA_LIST_SLOT_BYTES) * VA_LIST_SLOT_BYTES + VA_LIST_SLOT_BYTES;
+			}
+		}
 
-        @Override
-        public Builder addVarg(ValueLayout.OfInt layout, int value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+		return argLayoutSize;
+	}
 
-        @Override
-        public Builder addVarg(ValueLayout.OfLong layout, long value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+	/* Check whether the argument to be skipped exceeds the existing memory size in the VaList */
+	private void checkNextArgument(MemoryLayout argLayout, long argByteSize) {
+		if (argByteSize > segment.byteSize()) {
+			throw SharedUtils.newVaListNSEE(argLayout);
+		}
+	}
 
-        @Override
-        public Builder addVarg(ValueLayout.OfDouble layout, double value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+	@Override
+	public void skip(MemoryLayout... layouts) {
+		Objects.requireNonNull(layouts);
+		sessionImpl().checkValidState();
 
-        @Override
-        public Builder addVarg(ValueLayout.OfAddress layout, Addressable value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+		for (MemoryLayout layout : layouts) {
+			Objects.requireNonNull(layout);
+			long argByteSize = getAlignedArgSize(layout);
+			checkNextArgument(layout, argByteSize);
+			/* Skip to the next argument in the va_list buffer */
+			segment = segment.asSlice(argByteSize);
+		}
+	}
 
-        @Override
-        public Builder addVarg(GroupLayout layout, MemorySegment value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+	public static VaList ofAddress(MemoryAddress addr, MemorySession session) {
+		MemorySegment segment = MemorySegment.ofAddress(addr, Long.MAX_VALUE, session);
+		return new AixPPC64VaList(segment, session);
+	}
 
-        public VaList build() {
-            throw new InternalError("build() is not yet implemented"); //$NON-NLS-1$
-        }
-    }
+	@Override
+	public MemorySession session() {
+		return session;
+	}
+
+	@Override
+	public VaList copy() {
+		sessionImpl().checkValidState();
+		return new AixPPC64VaList(segment, session);
+	}
+
+	@Override
+	public MemoryAddress address() {
+		return segment.address();
+	}
+
+	@Override
+	public String toString() {
+		return "AixPPC64VaList{" + segment.address() + '}';
+	}
+
+	static Builder builder(MemorySession session) {
+		return new Builder(session);
+	}
+
+	public static non-sealed class Builder implements VaList.Builder {
+		private final MemorySession session;
+		private final List<SimpleVaArg> stackArgs = new ArrayList<>();
+
+		public Builder(MemorySession session) {
+			MemorySessionImpl.toSessionImpl(session).checkValidState();
+			this.session = session;
+		}
+
+		private Builder setArg(MemoryLayout layout, Object value) {
+			Objects.requireNonNull(layout);
+			Objects.requireNonNull(value);
+			stackArgs.add(new SimpleVaArg(layout, value));
+			return this;
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfInt layout, int value) {
+			return setArg(layout, value);
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfLong layout, long value) {
+			return setArg(layout, value);
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfDouble layout, double value) {
+			return setArg(layout, value);
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfAddress layout, Addressable value) {
+			return setArg(layout, value.address());
+		}
+
+		@Override
+		public Builder addVarg(GroupLayout layout, MemorySegment value) {
+			return setArg(layout, value);
+		}
+
+		public VaList build() {
+			if (stackArgs.isEmpty()) {
+				return EMPTY;
+			}
+
+			/* All primitves/pointer (aligned with 8 bytes) are directly stored in the va_list buffer
+			 * and all elements of stuct are totally copied to the va_list buffer (instead of storing
+			 * the va_list address), in which case we need to calculate the total byte size of the
+			 * buffer to be allocated for va_list.
+			 */
+			long totalArgsSize = stackArgs.stream().reduce(0L,
+					(accum, arg) -> accum + getAlignedArgSize(arg.layout), Long::sum);
+			SegmentAllocator allocator = SegmentAllocator.newNativeArena(session);
+			MemorySegment segment = allocator.allocate(totalArgsSize);
+			MemorySegment cursorSegment = segment;
+
+			for (SimpleVaArg arg : stackArgs) {
+				MemoryLayout argLayout = arg.layout;
+				TypeClass typeClass = TypeClass.classifyLayout(argLayout);
+				switch (typeClass) {
+					case PRIMITIVE, POINTER -> {
+						VarHandle argHandle = TypeClass.classifyVarHandle((ValueLayout)argLayout);
+						argHandle.set(cursorSegment, arg.value);
+					}
+					case STRUCT -> {
+						cursorSegment.copyFrom((MemorySegment)(arg.value));
+					}
+					default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
+				}
+				/* Move to the next argument by the aligned size of the current argument */
+				cursorSegment = cursorSegment.asSlice(getAlignedArgSize(argLayout));
+			}
+			return new AixPPC64VaList(segment, session);
+		}
+	}
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leVaList.java
@@ -33,123 +33,246 @@
 package jdk.internal.foreign.abi.ppc64.sysv;
 
 import java.lang.foreign.*;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
+import jdk.internal.foreign.abi.ppc64.TypeClass;
+import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.Scoped;
-import jdk.internal.foreign.Utils;
-import jdk.internal.foreign.abi.SharedUtils;
 import static jdk.internal.foreign.PlatformLayouts.SysVPPC64le;
 
 /**
- * This file serves as a placeholder for VaList on Linux/ppc64le as the code
- * at Java level is not yet implemented for the moment. Futher analysis on
- * the struct is required to understand how the struct is laid out in memory
- * (e.g. the type & size of each field in va_list) and how the registers are
- * allocated for va_list.
+ * This class implements VaList specific to Linux/ppc64le based on "64-Bit ELF V2 ABI
+ * Specification: Power Architecture"(Revision 1.5) against the code of VaList on
+ * x64/windows as the template.
+ *
+ * va_arg impl on Linux/ppc64le:
+ * typedef void * va_list;
+ *
+ * Specifically, va_list is simply a pointer (similar to the va_list on x64/windows) to a buffer
+ * with all supportted types of arugments, including struct (passed by value), pointer and
+ * primitive types, which are aligned with 8 bytes.
  */
 public non-sealed class SysVPPC64leVaList implements VaList, Scoped {
-    static final Class<?> CARRIER = MemoryAddress.class;
+	public static final Class<?> CARRIER = MemoryAddress.class;
 
-    public static VaList empty() {
-        throw new InternalError("empty() is not yet implemented"); //$NON-NLS-1$
-    }
+	/* Every primitive/pointer occupies 8 bytes and structs are aligned
+	 * with 8 bytes in the total size when stacking the va_list buffer.
+	 */
+	private static final long VA_LIST_SLOT_BYTES = 8;
+	private static final VaList EMPTY = new SharedUtils.EmptyVaList(MemoryAddress.NULL);
 
-    @Override
-    public int nextVarg(ValueLayout.OfInt layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	private MemorySegment segment;
+	private final MemorySession session;
 
-    @Override
-    public long nextVarg(ValueLayout.OfLong layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	private SysVPPC64leVaList(MemorySegment segment, MemorySession session) {
+		this.segment = segment;
+		this.session = session;
+	}
 
-    @Override
-    public double nextVarg(ValueLayout.OfDouble layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	public static final VaList empty() {
+		return EMPTY;
+	}
 
-    @Override
-    public MemoryAddress nextVarg(ValueLayout.OfAddress layout) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public int nextVarg(ValueLayout.OfInt layout) {
+		return Math.toIntExact((long)readArg(layout));
+	}
 
-    @Override
-    public MemorySegment nextVarg(GroupLayout layout, SegmentAllocator allocator) {
-        throw new InternalError("nextVarg() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public long nextVarg(ValueLayout.OfLong layout) {
+		return (long)readArg(layout);
+	}
 
-    @Override
-    public void skip(MemoryLayout... layouts) {
-        throw new InternalError("skip() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public double nextVarg(ValueLayout.OfDouble layout) {
+		return (double)readArg(layout);
+	}
 
-    public static VaList ofAddress(MemoryAddress ma, MemorySession session) {
-        throw new InternalError("ofAddress() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public MemoryAddress nextVarg(ValueLayout.OfAddress layout) {
+		return (MemoryAddress)readArg(layout);
+	}
 
-    @Override
-    public MemorySession session() {
-        throw new InternalError("session() is not yet implemented"); //$NON-NLS-1$
-    }
+	@Override
+	public MemorySegment nextVarg(GroupLayout layout, SegmentAllocator allocator) {
+		return (MemorySegment)readArg(layout, allocator);
+	}
 
-    @Override
-    public MemorySessionImpl sessionImpl() {
-        return MemorySessionImpl.toSessionImpl(session());
-    }
+	private Object readArg(MemoryLayout argLayout) {
+		return readArg(argLayout, SharedUtils.THROWING_ALLOCATOR);
+	}
 
-    @Override
-    public VaList copy() {
-        throw new InternalError("copy() is not yet implemented"); //$NON-NLS-1$
-    }
+	private Object readArg(MemoryLayout argLayout, SegmentAllocator allocator) {
+		Objects.requireNonNull(argLayout);
+		Objects.requireNonNull(allocator);
+		Object argument = null;
 
-    @Override
-    public MemoryAddress address() {
-        throw new InternalError("address() is not yet implemented"); //$NON-NLS-1$
-    }
+		TypeClass typeClass = TypeClass.classifyLayout(argLayout);
+		long argByteSize = getAlignedArgSize(argLayout);
+		checkNextArgument(argLayout, argByteSize);
 
-    @Override
-    public String toString() {
-        throw new InternalError("toString() is not yet implemented"); //$NON-NLS-1$
-    }
+		switch (typeClass) {
+			case PRIMITIVE, POINTER -> {
+				VarHandle argHandle = TypeClass.classifyVarHandle((ValueLayout)argLayout);
+				argument = argHandle.get(segment);
+			}
+			case STRUCT -> {
+				/* Copy the struct argument with the aligned size from the va_list buffer to allocated memory */
+				argument = allocator.allocate(argByteSize).copyFrom(segment.asSlice(0, argByteSize));
+			}
+			default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
+		}
 
-    static SysVPPC64leVaList.Builder builder(MemorySession session) {
-        return new SysVPPC64leVaList.Builder(session);
-    }
+		/* Move to the next argument in the va_list buffer */
+		segment = segment.asSlice(argByteSize);
+		return argument;
+	}
 
-    public static non-sealed class Builder implements VaList.Builder {
+	private static long getAlignedArgSize(MemoryLayout argLayout) {
+		long argLayoutSize = VA_LIST_SLOT_BYTES; // Always aligned with 8 bytes for primitives/pointer by default
 
-        public Builder(MemorySession session) {
-            throw new InternalError("Builder() is not yet implemented"); //$NON-NLS-1$
-        }
+		/* As with primitives, a struct should aligned with 8 bytes */
+		if (argLayout instanceof GroupLayout) {
+			argLayoutSize = argLayout.byteSize();
+			if ((argLayoutSize % VA_LIST_SLOT_BYTES) > 0) {
+				argLayoutSize = (argLayoutSize / VA_LIST_SLOT_BYTES) * VA_LIST_SLOT_BYTES + VA_LIST_SLOT_BYTES;
+			}
+		}
 
-        @Override
-        public Builder addVarg(ValueLayout.OfInt layout, int value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+		return argLayoutSize;
+	}
 
-        @Override
-        public Builder addVarg(ValueLayout.OfLong layout, long value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+	/* Check whether the argument to be skipped exceeds the existing memory size in the VaList */
+	private void checkNextArgument(MemoryLayout argLayout, long argByteSize) {
+		if (argByteSize > segment.byteSize()) {
+			throw SharedUtils.newVaListNSEE(argLayout);
+		}
+	}
 
-        @Override
-        public Builder addVarg(ValueLayout.OfDouble layout, double value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+	@Override
+	public void skip(MemoryLayout... layouts) {
+		Objects.requireNonNull(layouts);
+		sessionImpl().checkValidState();
 
-        @Override
-        public Builder addVarg(ValueLayout.OfAddress layout, Addressable value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+		for (MemoryLayout layout : layouts) {
+			Objects.requireNonNull(layout);
+			long argByteSize = getAlignedArgSize(layout);
+			checkNextArgument(layout, argByteSize);
+			/* Skip to the next argument in the va_list buffer */
+			segment = segment.asSlice(argByteSize);
+		}
+	}
 
-        @Override
-        public Builder addVarg(GroupLayout layout, MemorySegment value) {
-            throw new InternalError("addVarg() is not yet implemented"); //$NON-NLS-1$
-        }
+	public static VaList ofAddress(MemoryAddress addr, MemorySession session) {
+		MemorySegment segment = MemorySegment.ofAddress(addr, Long.MAX_VALUE, session);
+		return new SysVPPC64leVaList(segment, session);
+	}
 
-        public VaList build() {
-            throw new InternalError("build() is not yet implemented"); //$NON-NLS-1$
-        }
-    }
+	@Override
+	public MemorySession session() {
+		return session;
+	}
+
+	@Override
+	public VaList copy() {
+		sessionImpl().checkValidState();
+		return new SysVPPC64leVaList(segment, session);
+	}
+
+	@Override
+	public MemoryAddress address() {
+		return segment.address();
+	}
+
+	@Override
+	public String toString() {
+		return "SysVPPC64leVaList{" + segment.address() + '}';
+	}
+
+	static Builder builder(MemorySession session) {
+		return new Builder(session);
+	}
+
+	public static non-sealed class Builder implements VaList.Builder {
+		private final MemorySession session;
+		private final List<SimpleVaArg> stackArgs = new ArrayList<>();
+
+		public Builder(MemorySession session) {
+			MemorySessionImpl.toSessionImpl(session).checkValidState();
+			this.session = session;
+		}
+
+		private Builder setArg(MemoryLayout layout, Object value) {
+			Objects.requireNonNull(layout);
+			Objects.requireNonNull(value);
+			stackArgs.add(new SimpleVaArg(layout, value));
+			return this;
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfInt layout, int value) {
+			return setArg(layout, value);
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfLong layout, long value) {
+			return setArg(layout, value);
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfDouble layout, double value) {
+			return setArg(layout, value);
+		}
+
+		@Override
+		public Builder addVarg(ValueLayout.OfAddress layout, Addressable value) {
+			return setArg(layout, value.address());
+		}
+
+		@Override
+		public Builder addVarg(GroupLayout layout, MemorySegment value) {
+			return setArg(layout, value);
+		}
+
+		public VaList build() {
+			if (stackArgs.isEmpty()) {
+				return EMPTY;
+			}
+
+			/* All primitves/pointer (aligned with 8 bytes) are directly stored in the va_list buffer
+			 * and all elements of stuct are totally copied to the va_list buffer (instead of storing
+			 * the va_list address), in which case we need to calculate the total byte size of the
+			 * buffer to be allocated for va_list.
+			 */
+			long totalArgsSize = stackArgs.stream().reduce(0L,
+					(accum, arg) -> accum + getAlignedArgSize(arg.layout), Long::sum);
+			SegmentAllocator allocator = SegmentAllocator.newNativeArena(session);
+			MemorySegment segment = allocator.allocate(totalArgsSize);
+			MemorySegment cursorSegment = segment;
+
+			for (SimpleVaArg arg : stackArgs) {
+				MemoryLayout argLayout = arg.layout;
+				TypeClass typeClass = TypeClass.classifyLayout(argLayout);
+				switch (typeClass) {
+					case PRIMITIVE, POINTER -> {
+						VarHandle argHandle = TypeClass.classifyVarHandle((ValueLayout)argLayout);
+						argHandle.set(cursorSegment, arg.value);
+					}
+					case STRUCT -> {
+						cursorSegment.copyFrom((MemorySegment)(arg.value));
+					}
+					default -> throw new IllegalStateException("Unsupported TypeClass: " + typeClass);
+				}
+				/* Move to the next argument by the aligned size of the current argument */
+				cursorSegment = cursorSegment.asSlice(getAlignedArgSize(argLayout));
+			}
+			return new SysVPPC64leVaList(segment, session);
+		}
+	}
 }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -23,6 +23,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../
@@ -36,6 +42,8 @@
  *          java.base/jdk.internal.foreign.abi.aarch64.linux
  *          java.base/jdk.internal.foreign.abi.aarch64.macos
  *          java.base/jdk.internal.foreign.abi.aarch64.windows
+ *          java.base/jdk.internal.foreign.abi.ppc64.aix
+ *          java.base/jdk.internal.foreign.abi.ppc64.sysv
  * @run testng/othervm --enable-native-access=ALL-UNNAMED VaListTest
  */
 
@@ -43,6 +51,8 @@ import java.lang.foreign.*;
 import java.lang.foreign.VaList;
 import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
+import jdk.internal.foreign.abi.ppc64.aix.AixPPC64Linker;
+import jdk.internal.foreign.abi.ppc64.sysv.SysVPPC64leLinker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
 import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 import org.testng.annotations.DataProvider;
@@ -135,6 +145,10 @@ public class VaListTest extends NativeTestHelper {
             = actions -> LinuxAArch64Linker.newVaList(actions, MemorySession.openImplicit());
     private static final Function<Consumer<VaList.Builder>, VaList> macAArch64VaListFactory
             = actions -> MacOsAArch64Linker.newVaList(actions, MemorySession.openImplicit());
+    private static final Function<Consumer<VaList.Builder>, VaList> aixPPC64VaListFactory
+            = actions -> AixPPC64Linker.newVaList(actions, MemorySession.openImplicit());
+    private static final Function<Consumer<VaList.Builder>, VaList> sysVPPC64leVaListFactory
+            = actions -> SysVPPC64leLinker.newVaList(actions, MemorySession.openImplicit());
     private static final Function<Consumer<VaList.Builder>, VaList> platformVaListFactory
             = (builder) -> VaList.make(builder, MemorySession.openConfined());
 
@@ -146,6 +160,10 @@ public class VaListTest extends NativeTestHelper {
             = LinuxAArch64Linker::newVaList;
     private static final BiFunction<Consumer<VaList.Builder>, MemorySession, VaList> macAArch64VaListScopedFactory
             = MacOsAArch64Linker::newVaList;
+    private static final BiFunction<Consumer<VaList.Builder>, MemorySession, VaList> aixPPC64VaListScopedFactory
+            = AixPPC64Linker::newVaList;
+    private static final BiFunction<Consumer<VaList.Builder>, MemorySession, VaList> sysVPPC64leVaListScopedFactory
+            = SysVPPC64leLinker::newVaList;
     private static final BiFunction<Consumer<VaList.Builder>, MemorySession, VaList> platformVaListScopedFactory
             = VaList::make;
 
@@ -157,11 +175,13 @@ public class VaListTest extends NativeTestHelper {
         BiFunction<Integer, VaList, Integer> sumIntsNative
                 = MethodHandleProxies.asInterfaceInstance(BiFunction.class, MH_sumInts);
         return new Object[][]{
-                { winVaListFactory,          sumIntsJavaFact.apply(Win64.C_INT),   Win64.C_INT   },
-                { sysvVaListFactory,         sumIntsJavaFact.apply(SysV.C_INT),    SysV.C_INT    },
-                { linuxAArch64VaListFactory, sumIntsJavaFact.apply(AArch64.C_INT), AArch64.C_INT },
-                { macAArch64VaListFactory,   sumIntsJavaFact.apply(AArch64.C_INT), AArch64.C_INT },
-                { platformVaListFactory,     sumIntsNative,                        C_INT         },
+                { winVaListFactory,          sumIntsJavaFact.apply(Win64.C_INT),        Win64.C_INT       },
+                { sysvVaListFactory,         sumIntsJavaFact.apply(SysV.C_INT),         SysV.C_INT        },
+                { linuxAArch64VaListFactory, sumIntsJavaFact.apply(AArch64.C_INT),      AArch64.C_INT     },
+                { macAArch64VaListFactory,   sumIntsJavaFact.apply(AArch64.C_INT),      AArch64.C_INT     },
+                { aixPPC64VaListFactory,     sumIntsJavaFact.apply(AIX.C_INT),          AIX.C_INT         },
+                { sysVPPC64leVaListFactory,  sumIntsJavaFact.apply(SysVPPC64le.C_INT),  SysVPPC64le.C_INT },
+                { platformVaListFactory,     sumIntsNative,                             C_INT             },
         };
     }
 
@@ -185,11 +205,13 @@ public class VaListTest extends NativeTestHelper {
         BiFunction<Integer, VaList, Double> sumDoublesNative
                 = MethodHandleProxies.asInterfaceInstance(BiFunction.class, MH_sumDoubles);
         return new Object[][]{
-                { winVaListFactory,          sumDoublesJavaFact.apply(Win64.C_DOUBLE),   Win64.C_DOUBLE   },
-                { sysvVaListFactory,         sumDoublesJavaFact.apply(SysV.C_DOUBLE),    SysV.C_DOUBLE    },
-                { linuxAArch64VaListFactory, sumDoublesJavaFact.apply(AArch64.C_DOUBLE), AArch64.C_DOUBLE },
-                { macAArch64VaListFactory,   sumDoublesJavaFact.apply(AArch64.C_DOUBLE), AArch64.C_DOUBLE },
-                { platformVaListFactory,     sumDoublesNative,                           C_DOUBLE         },
+                { winVaListFactory,          sumDoublesJavaFact.apply(Win64.C_DOUBLE),        Win64.C_DOUBLE       },
+                { sysvVaListFactory,         sumDoublesJavaFact.apply(SysV.C_DOUBLE),         SysV.C_DOUBLE        },
+                { linuxAArch64VaListFactory, sumDoublesJavaFact.apply(AArch64.C_DOUBLE),      AArch64.C_DOUBLE     },
+                { macAArch64VaListFactory,   sumDoublesJavaFact.apply(AArch64.C_DOUBLE),      AArch64.C_DOUBLE     },
+                { aixPPC64VaListFactory,     sumDoublesJavaFact.apply(AIX.C_DOUBLE),          AIX.C_DOUBLE         },
+                { sysVPPC64leVaListFactory,  sumDoublesJavaFact.apply(SysVPPC64le.C_DOUBLE),  SysVPPC64le.C_DOUBLE },
+                { platformVaListFactory,     sumDoublesNative,                                C_DOUBLE             },
         };
     }
 
@@ -215,11 +237,13 @@ public class VaListTest extends NativeTestHelper {
                 };
         Function<VaList, Integer> getIntNative = MethodHandleProxies.asInterfaceInstance(Function.class, MH_getInt);
         return new Object[][]{
-                { winVaListFactory,          getIntJavaFact.apply(Win64.C_POINTER),   Win64.C_POINTER   },
-                { sysvVaListFactory,         getIntJavaFact.apply(SysV.C_POINTER),    SysV.C_POINTER    },
-                { linuxAArch64VaListFactory, getIntJavaFact.apply(AArch64.C_POINTER), AArch64.C_POINTER },
-                { macAArch64VaListFactory,   getIntJavaFact.apply(AArch64.C_POINTER), AArch64.C_POINTER },
-                { platformVaListFactory,     getIntNative,                            C_POINTER         },
+                { winVaListFactory,          getIntJavaFact.apply(Win64.C_POINTER),        Win64.C_POINTER       },
+                { sysvVaListFactory,         getIntJavaFact.apply(SysV.C_POINTER),         SysV.C_POINTER        },
+                { linuxAArch64VaListFactory, getIntJavaFact.apply(AArch64.C_POINTER),      AArch64.C_POINTER     },
+                { macAArch64VaListFactory,   getIntJavaFact.apply(AArch64.C_POINTER),      AArch64.C_POINTER     },
+                { aixPPC64VaListFactory,     getIntJavaFact.apply(AIX.C_POINTER),          AIX.C_POINTER         },
+                { sysVPPC64leVaListFactory,  getIntJavaFact.apply(SysVPPC64le.C_POINTER),  SysVPPC64le.C_POINTER },
+                { platformVaListFactory,     getIntNative,                                 C_POINTER             },
         };
     }
 
@@ -270,11 +294,13 @@ public class VaListTest extends NativeTestHelper {
                     pointLayout, VH_Point_x, VH_Point_y  };
         };
         return new Object[][]{
-                argsFact.apply(winVaListFactory,          Win64.C_INT,   sumStructJavaFact),
-                argsFact.apply(sysvVaListFactory,         SysV.C_INT,    sumStructJavaFact),
-                argsFact.apply(linuxAArch64VaListFactory, AArch64.C_INT, sumStructJavaFact),
-                argsFact.apply(macAArch64VaListFactory,   AArch64.C_INT, sumStructJavaFact),
-                argsFact.apply(platformVaListFactory,     C_INT,         sumStructNativeFact),
+                argsFact.apply(winVaListFactory,          Win64.C_INT,       sumStructJavaFact),
+                argsFact.apply(sysvVaListFactory,         SysV.C_INT,        sumStructJavaFact),
+                argsFact.apply(linuxAArch64VaListFactory, AArch64.C_INT,     sumStructJavaFact),
+                argsFact.apply(macAArch64VaListFactory,   AArch64.C_INT,     sumStructJavaFact),
+                argsFact.apply(aixPPC64VaListFactory,     AIX.C_INT,         sumStructJavaFact),
+                argsFact.apply(sysVPPC64leVaListFactory,  SysVPPC64le.C_INT, sumStructJavaFact),
+                argsFact.apply(platformVaListFactory,     C_INT,           sumStructNativeFact),
         };
     }
 
@@ -323,11 +349,13 @@ public class VaListTest extends NativeTestHelper {
                     BigPoint_LAYOUT, VH_BigPoint_x, VH_BigPoint_y  };
         };
         return new Object[][]{
-                argsFact.apply(winVaListFactory,          Win64.C_LONG_LONG,   sumStructJavaFact),
-                argsFact.apply(sysvVaListFactory,         SysV.C_LONG_LONG,    sumStructJavaFact),
-                argsFact.apply(linuxAArch64VaListFactory, AArch64.C_LONG_LONG, sumStructJavaFact),
-                argsFact.apply(macAArch64VaListFactory,   AArch64.C_LONG_LONG, sumStructJavaFact),
-                argsFact.apply(platformVaListFactory,     C_LONG_LONG,         sumStructNativeFact),
+                argsFact.apply(winVaListFactory,          Win64.C_LONG_LONG,       sumStructJavaFact),
+                argsFact.apply(sysvVaListFactory,         SysV.C_LONG_LONG,        sumStructJavaFact),
+                argsFact.apply(linuxAArch64VaListFactory, AArch64.C_LONG_LONG,     sumStructJavaFact),
+                argsFact.apply(macAArch64VaListFactory,   AArch64.C_LONG_LONG,     sumStructJavaFact),
+                argsFact.apply(aixPPC64VaListFactory,     AIX.C_LONG_LONG,         sumStructJavaFact),
+                argsFact.apply(sysVPPC64leVaListFactory,  SysVPPC64le.C_LONG_LONG, sumStructJavaFact),
+                argsFact.apply(platformVaListFactory,     C_LONG_LONG,           sumStructNativeFact),
         };
     }
 
@@ -376,11 +404,13 @@ public class VaListTest extends NativeTestHelper {
                     FloatPoint_LAYOUT, VH_FloatPoint_x, VH_FloatPoint_y  };
         };
         return new Object[][]{
-                argsFact.apply(winVaListFactory,          Win64.C_FLOAT,   sumStructJavaFact),
-                argsFact.apply(sysvVaListFactory,         SysV.C_FLOAT,    sumStructJavaFact),
-                argsFact.apply(linuxAArch64VaListFactory, AArch64.C_FLOAT, sumStructJavaFact),
-                argsFact.apply(macAArch64VaListFactory,   AArch64.C_FLOAT, sumStructJavaFact),
-                argsFact.apply(platformVaListFactory,     C_FLOAT,         sumStructNativeFact),
+                argsFact.apply(winVaListFactory,          Win64.C_FLOAT,       sumStructJavaFact),
+                argsFact.apply(sysvVaListFactory,         SysV.C_FLOAT,        sumStructJavaFact),
+                argsFact.apply(linuxAArch64VaListFactory, AArch64.C_FLOAT,     sumStructJavaFact),
+                argsFact.apply(macAArch64VaListFactory,   AArch64.C_FLOAT,     sumStructJavaFact),
+                argsFact.apply(aixPPC64VaListFactory,     AIX.C_FLOAT,         sumStructJavaFact),
+                argsFact.apply(sysVPPC64leVaListFactory,  SysVPPC64le.C_FLOAT, sumStructJavaFact),
+                argsFact.apply(platformVaListFactory,     C_FLOAT,           sumStructNativeFact),
         };
     }
 
@@ -441,7 +471,9 @@ public class VaListTest extends NativeTestHelper {
                 argsFact.apply(winVaListFactory,          Win64.C_LONG_LONG,   sumStructJavaFact),
                 argsFact.apply(sysvVaListFactory,         SysV.C_LONG_LONG,    sumStructJavaFact),
                 argsFact.apply(linuxAArch64VaListFactory, AArch64.C_LONG_LONG, sumStructJavaFact),
-                argsFact.apply(macAArch64VaListFactory,   AArch64.C_LONG_LONG, sumStructJavaFact),
+                argsFact.apply(macAArch64VaListFactory,   AArch64.C_LONG_LONG,     sumStructJavaFact),
+                argsFact.apply(aixPPC64VaListFactory,     AIX.C_LONG_LONG,         sumStructJavaFact),
+                argsFact.apply(sysVPPC64leVaListFactory,  SysVPPC64le.C_LONG_LONG, sumStructJavaFact),
                 argsFact.apply(platformVaListFactory,     C_LONG_LONG,         sumStructNativeFact),
         };
     }
@@ -492,11 +524,13 @@ public class VaListTest extends NativeTestHelper {
             }
         };
         return new Object[][]{
-                { winVaListFactory,           sumStackJavaFact.apply(Win64.C_LONG_LONG, Win64.C_DOUBLE),     Win64.C_LONG_LONG,   Win64.C_DOUBLE   },
-                { sysvVaListFactory,          sumStackJavaFact.apply(SysV.C_LONG_LONG, SysV.C_DOUBLE),       SysV.C_LONG_LONG,    SysV.C_DOUBLE    },
-                { linuxAArch64VaListFactory,  sumStackJavaFact.apply(AArch64.C_LONG_LONG, AArch64.C_DOUBLE), AArch64.C_LONG_LONG, AArch64.C_DOUBLE },
-                { macAArch64VaListFactory,    sumStackJavaFact.apply(AArch64.C_LONG_LONG, AArch64.C_DOUBLE), AArch64.C_LONG_LONG, AArch64.C_DOUBLE },
-                { platformVaListFactory,      sumStackNative,                                                C_LONG_LONG,         C_DOUBLE         },
+                { winVaListFactory,           sumStackJavaFact.apply(Win64.C_LONG_LONG, Win64.C_DOUBLE),             Win64.C_LONG_LONG,   Win64.C_DOUBLE           },
+                { sysvVaListFactory,          sumStackJavaFact.apply(SysV.C_LONG_LONG, SysV.C_DOUBLE),               SysV.C_LONG_LONG,    SysV.C_DOUBLE            },
+                { linuxAArch64VaListFactory,  sumStackJavaFact.apply(AArch64.C_LONG_LONG, AArch64.C_DOUBLE),         AArch64.C_LONG_LONG, AArch64.C_DOUBLE         },
+                { macAArch64VaListFactory,    sumStackJavaFact.apply(AArch64.C_LONG_LONG, AArch64.C_DOUBLE),         AArch64.C_LONG_LONG, AArch64.C_DOUBLE         },
+                { aixPPC64VaListFactory,      sumStackJavaFact.apply(AIX.C_LONG_LONG, AIX.C_DOUBLE),                 AIX.C_LONG_LONG, AIX.C_DOUBLE                 },
+                { sysVPPC64leVaListFactory,   sumStackJavaFact.apply(SysVPPC64le.C_LONG_LONG, SysVPPC64le.C_DOUBLE), SysVPPC64le.C_LONG_LONG, SysVPPC64le.C_DOUBLE },
+                { platformVaListFactory,      sumStackNative,                                                        C_LONG_LONG,         C_DOUBLE                 },
         };
     }
 
@@ -550,6 +584,10 @@ public class VaListTest extends NativeTestHelper {
                 { linuxAArch64VaListFactory.apply(b -> {}) },
                 { MacOsAArch64Linker.emptyVaList()         },
                 { macAArch64VaListFactory.apply(b -> {})   },
+                { AixPPC64Linker.emptyVaList()             },
+                { aixPPC64VaListFactory.apply(b -> {})     },
+                { SysVPPC64leLinker.emptyVaList()          },
+                { sysVPPC64leVaListFactory.apply(b -> {})  },
         };
     }
 
@@ -561,11 +599,13 @@ public class VaListTest extends NativeTestHelper {
         BiFunction<Integer, VaList, Integer> sumIntsNative
                 = MethodHandleProxies.asInterfaceInstance(BiFunction.class, MH_sumInts);
         return new Object[][]{
-                { winVaListScopedFactory,          sumIntsJavaFact.apply(Win64.C_INT),   Win64.C_INT   },
-                { sysvVaListScopedFactory,         sumIntsJavaFact.apply(SysV.C_INT),    SysV.C_INT    },
-                { linuxAArch64VaListScopedFactory, sumIntsJavaFact.apply(AArch64.C_INT), AArch64.C_INT },
-                { macAArch64VaListScopedFactory,   sumIntsJavaFact.apply(AArch64.C_INT), AArch64.C_INT },
-                { platformVaListScopedFactory,     sumIntsNative,                        C_INT         },
+                { winVaListScopedFactory,          sumIntsJavaFact.apply(Win64.C_INT),       Win64.C_INT       },
+                { sysvVaListScopedFactory,         sumIntsJavaFact.apply(SysV.C_INT),        SysV.C_INT        },
+                { linuxAArch64VaListScopedFactory, sumIntsJavaFact.apply(AArch64.C_INT),     AArch64.C_INT     },
+                { macAArch64VaListScopedFactory,   sumIntsJavaFact.apply(AArch64.C_INT),     AArch64.C_INT     },
+                { aixPPC64VaListScopedFactory,     sumIntsJavaFact.apply(AIX.C_INT),         AIX.C_INT         },
+                { sysVPPC64leVaListScopedFactory,  sumIntsJavaFact.apply(SysVPPC64le.C_INT), SysVPPC64le.C_INT },
+                { platformVaListScopedFactory,     sumIntsNative,                            C_INT             },
         };
     }
 
@@ -609,10 +649,12 @@ public class VaListTest extends NativeTestHelper {
     @DataProvider
     public Object[][] copy() {
         return new Object[][] {
-                { winVaListScopedFactory,          Win64.C_INT   },
-                { sysvVaListScopedFactory,         SysV.C_INT    },
-                { linuxAArch64VaListScopedFactory, AArch64.C_INT },
-                { macAArch64VaListScopedFactory,   AArch64.C_INT },
+                { winVaListScopedFactory,          Win64.C_INT       },
+                { sysvVaListScopedFactory,         SysV.C_INT        },
+                { linuxAArch64VaListScopedFactory, AArch64.C_INT     },
+                { macAArch64VaListScopedFactory,   AArch64.C_INT     },
+                { aixPPC64VaListScopedFactory,     AIX.C_INT         },
+                { sysVPPC64leVaListScopedFactory,  SysVPPC64le.C_INT },
         };
     }
 
@@ -829,7 +871,9 @@ public class VaListTest extends NativeTestHelper {
             winVaListFactory,
             sysvVaListFactory,
             linuxAArch64VaListFactory,
-            macAArch64VaListFactory
+            macAArch64VaListFactory,
+            aixPPC64VaListFactory,
+            sysVPPC64leVaListFactory
         );
         List<List<MemoryLayout>> contentsCases = List.of(
             List.of(JAVA_INT),


### PR DESCRIPTION
The changes aim to enable the VaList support on Power (Linux & AIX)
by implementing the VaList specific APIs in OpenJDK given the underlying
code has been offered in OpenJ9.

Note:
The PR is part of FFI downcall & upcall work at
https://github.com/eclipse-openj9/openj9/issues/12412 and https://github.com/eclipse-openj9/openj9/issues/15068.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>