### PR TITLE
Set OpenJDK test properties to false in OpenJ9PropsExt

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -39,6 +39,10 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.bits", vmBits());
             map.put("vm.compiler2.enabled", "false");
             map.put("vm.continuations", "false");
+            map.put("vm.gc.G1", "false");
+            map.put("vm.gc.Parallel", "false");
+            map.put("vm.gc.Serial", "false");
+            map.put("vm.gc.Shenandoah", "false");
             map.put("vm.gc.Z", "false");
             map.put("vm.graal.enabled", "false");
             map.put("vm.hasJFR", "false");


### PR DESCRIPTION
Set following OpenJDK test properties to false:
```
vm.gc.G1
vm.gc.Parallel
vm.gc.Serial
vm.gc.Shenandoah
```

Verified at [an internal grinder](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/27445/console)
Will port to JDKNext after approval.

Issue https://github.com/eclipse-openj9/openj9/issues/15875

Signed-off-by: Jason Feng <fengj@ca.ibm.com>