### PR TITLE
Enable building JVMTI serviceability tests

### DIFF
--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -30,7 +30,6 @@ JVM_MAIN_LIB_TARGETS := j9vm-build
 JVM_MAIN_TARGETS := j9vm-build
 JVM_TOOLS_TARGETS :=
 JVM_DOCS_TARGETS :=
-JVM_TEST_IMAGE_TARGETS := test-image-openj9
 DEFAULT_JMOD_DEPS := j9vm-build
 PHASE_MAKEDIRS := $(TOPDIR)/closed/make $(PHASE_MAKEDIRS)
 
@@ -81,6 +80,8 @@ endif
 ifneq ($(COMPILE_TYPE), cross)
 	$(JDK_OUTPUTDIR)/bin/java -version 2>&1 | $(TEE) $(TEST_IMAGE_DIR)/openj9/java-version.txt
 endif
+
+test-image : test-image-openj9
 
 ALL_TARGETS += test-image-openj9
 

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
 # ===========================================================================
 
 ################################################################################
@@ -231,6 +231,8 @@ $(eval $(call DeclareRecipesForPhase, LAUNCHER, \
 
 ALL_TARGETS += $(LAUNCHER_TARGETS)
 
+ifeq ($(OPENJ9_TOPDIR),) # not OpenJ9
+
 ################################################################################
 # Build hotspot target
 
@@ -299,6 +301,8 @@ $(eval $(call SetupTarget, compile-commands-hotspot, \
 ))
 
 ALL_TARGETS += $(COMPILE_COMMANDS_TARGETS_HOTSPOT) $(COMPILE_COMMANDS_TARGETS_JDK)
+
+endif # not OpenJ9
 
 ################################################################################
 # VS Code projects
@@ -1168,13 +1172,8 @@ all-docs-bundles: docs-jdk-bundles docs-javase-bundles docs-reference-bundles
 
 # This target builds the test image
 test-image: prepare-test-image test-image-jdk-jtreg-native \
-    test-image-demos-jdk \
+    test-image-demos-jdk test-image-libtest-jtreg-native \
     test-image-lib-native
-
-# OpenJ9 builds don't have the sources required to build test-image-libtest-jtreg-native.
-ifeq ($(OPENJ9_TOPDIR),)
-test-image: test-image-libtest-jtreg-native
-endif
 
 ifneq ($(JVM_TEST_IMAGE_TARGETS), )
   # If JVM_TEST_IMAGE_TARGETS is externally defined, use it instead of the


### PR DESCRIPTION
Remove dependencies of `test-image-libtest-jtreg-native` on unavailable hotspot targets.