### PR TITLE
Add --openssl-repo option for downloading OpenSSL source

### DIFF
--- a/closed/get_openssl_source.sh
+++ b/closed/get_openssl_source.sh
@@ -23,22 +23,27 @@
 # ===========================================================================
 
 usage() {
-	echo "Usage: $0 [-h|--help] [--openssl-version=<openssl version 1.0.2 and above to download>]"
+	echo "Usage: $0 [-h|--help] [--openssl-repo=<repo URL>] [--openssl-version=<openssl version 1.0.2 and above to download>]"
 	echo "where:"
 	echo "  -h|--help             print this help, then exit"
+	echo "  --openssl-repo        OpenSSL repository. By default, https://github.com/openssl/openssl.git"
 	echo "  --openssl-version     OpenSSL version to download. For example, 1.1.1"
 	echo ""
 	exit 1
 }
 
 OPENSSL_VERSION=""
-GIT_URL="https://github.com/openssl/openssl.git"
+OPENSSL_URL="https://github.com/openssl/openssl.git"
 
 for i in "$@"
 do
 	case $i in
 		-h | --help )
 		usage
+		;;
+
+		--openssl-repo=* )
+		OPENSSL_URL="${i#*=}"
 		;;
 
 		--openssl-version=* )
@@ -85,8 +90,8 @@ if [ -f "openssl/openssl_version.txt" ]; then
 fi
 
 echo ""
-echo "Cloning OpenSSL version $OPENSSL_VERSION"
-git clone --depth=1 -b $OPENSSL_SOURCE_TAG $GIT_URL
+echo "Cloning OpenSSL version $OPENSSL_VERSION from $OPENSSL_URL"
+git clone --depth=1 -b $OPENSSL_SOURCE_TAG $OPENSSL_URL
 
 echo $OPENSSL_SOURCE_TAG > openssl/openssl_version.txt
 

--- a/get_source.sh
+++ b/get_source.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ usage() {
 	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -omr-reference    a local repo to use as a clone reference"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
+	echo "  --openssl-repo    Specify the OpenSSL repository to download from"
 	echo "  --openssl-version Specify the version of OpenSSL source to download"
 	echo ""
 	exit 1
@@ -58,6 +59,10 @@ for i in "$@" ; do
 
 		-openj9-repo=* | -openj9-branch=* | -openj9-sha=* | -openj9-reference=* | -omr-repo=* | -omr-branch=* | -omr-sha=* | -omr-reference=* | -parallel=* )
 			j9options="${j9options} ${i}"
+			;;
+
+		--openssl-repo=* )
+			openssloptions="${openssloptions} ${i}"
 			;;
 
 		--openssl-version=* )


### PR DESCRIPTION
Port of https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/624 for jdk19.