### PR TITLE
Enable vm.continuations option for testing

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -39,7 +39,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.bits", vmBits());
             map.put("vm.cds", "false");
             map.put("vm.compiler2.enabled", "false");
-            map.put("vm.continuations", "false");
+            map.put("vm.continuations", "true");
             map.put("vm.flagless", "true");
             map.put("vm.gc.G1", "false");
             map.put("vm.gc.Parallel", "false");


### PR DESCRIPTION
Depends: https://github.com/adoptium/aqa-tests/pull/4087

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>