### PR TITLE
Use the OpenSSL PKCS12 method for PBE and simplify NativeCrypto property checking

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -33,9 +33,24 @@ import jdk.internal.ref.CleanerFactory;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.CallerSensitive;
 
+import sun.security.action.GetPropertyAction;
+
 public class NativeCrypto {
 
+    /* Define constants for the native digest algorithm indices. */
+    public static final int SHA1_160 = 0;
+    public static final int SHA2_224 = 1;
+    public static final int SHA2_256 = 2;
+    public static final int SHA5_384 = 3;
+    public static final int SHA5_512 = 4;
+
     private static final Cleaner ECKeyCleaner = CleanerFactory.cleaner();
+
+    private static final boolean useNativeCrypto = Boolean.parseBoolean(
+            GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto", "true"));
+
+    private static final boolean traceEnabled = Boolean.parseBoolean(
+            GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace", "false"));
 
     //ossl_vers:
     // -1 : library load failed
@@ -44,7 +59,6 @@ public class NativeCrypto {
     private static final int ossl_ver = AccessController.doPrivileged(
             (PrivilegedAction<Integer>) () -> {
                 int ossl_ver;
-                boolean traceEnabled = Boolean.getBoolean("jdk.nativeCryptoTrace");
                 try {
                     System.loadLibrary("jncrypto"); // check for native library
                     // load OpenSSL crypto library dynamically
@@ -66,6 +80,92 @@ public class NativeCrypto {
 
     public static final int getVersion() {
         return ossl_ver;
+    }
+
+    /**
+     * Check whether native crypto is enabled. Note that, by default, native
+     * crypto is enabled (the native crypto library implementation is used).
+     *
+     * The property 'jdk.nativeCrypto' is used to control enablement of all
+     * native cryptos (Digest, CBC, GCM, RSA, ChaCha20, EC, and PBE), while
+     * the given property should be used to control enablement of the given
+     * native crypto algorithm.
+     *
+     * @param property the property used to control enablement of the given
+     *                 algorithm
+     * @param name the name of the class or the algorithm
+     * @return whether the given native crypto algorithm is enabled
+     */
+    public static final boolean isAlgorithmEnabled(String property, String name) {
+        return isAlgorithmEnabled(property, name, true, null);
+    }
+
+    /**
+     * Check whether native crypto is enabled. Note that, by default, native
+     * crypto is enabled (the native crypto library implementation is used).
+     *
+     * The property 'jdk.nativeCrypto' is used to control enablement of all
+     * native cryptos (Digest, CBC, GCM, RSA, ChaCha20, EC, and PBE), while
+     * the given property should be used to control enablement of the given
+     * native crypto algorithm.
+     *
+     * This method is used for native cryptos that have additional requirements
+     * in order to load.
+     *
+     * @param property the property used to control enablement of the given
+     *                 algorithm
+     * @param name the name of the class or the algorithm
+     * @param satisfied whether the additional requirements are met
+     * @param explanation explanation if the native crypto is not loaded
+     *                    due to the additional requirements not being met
+     * @return whether the given native crypto algorithm is enabled
+     */
+    public static final boolean isAlgorithmEnabled(String property, String name, boolean satisfied, String explanation) {
+        boolean useNativeAlgorithm = false;
+        if (useNativeCrypto) {
+            useNativeAlgorithm = Boolean.parseBoolean(
+                    GetPropertyAction.privilegedGetProperty(property, "true"));
+        }
+        if (useNativeAlgorithm) {
+            /*
+             * User wants to use the native crypto implementation. Ensure that the
+             * native crypto library is loaded successfully. Otherwise, issue a warning
+             * message and fall back to the built-in java crypto implementation.
+             */
+            if (isLoaded()) {
+                if (satisfied) {
+                    if (traceEnabled) {
+                        System.err.println(name + " - using native crypto library.");
+                    }
+                } else {
+                    useNativeAlgorithm = false;
+                    if (traceEnabled) {
+                        System.err.println("Warning: " + name + " native requirements not satisfied. " +
+                                explanation + " Using Java crypto implementation.");
+                    }
+                }
+            } else {
+                useNativeAlgorithm = false;
+                if (traceEnabled) {
+                    System.err.println("Warning: Native crypto library load failed." +
+                            " Using Java crypto implementation.");
+                }
+            }
+        } else {
+            if (traceEnabled) {
+                System.err.println(name + " native crypto implementation disabled." +
+                        " Using Java crypto implementation.");
+            }
+        }
+        return useNativeAlgorithm;
+    }
+
+    public static final boolean isEnabled() {
+        return useNativeCrypto;
+    }
+
+    public static final boolean isTraceEnabled() {
+        return traceEnabled;
     }
 
     private NativeCrypto() {
@@ -294,5 +394,15 @@ public class NativeCrypto {
                                         int secretLen);
 
     public final native boolean ECNativeGF2m();
+
+    public final native int PBEDerive(byte[] password,
+                                      int passwordLength,
+                                      byte[] salt,
+                                      int saltLength,
+                                      byte[] key,
+                                      int iterations,
+                                      int n,
+                                      int id,
+                                      int hashAlgorithm);
 
 }

--- a/closed/src/java.base/share/classes/sun/security/provider/NativeSHA.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeSHA.java
@@ -24,11 +24,13 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  */
 
 package sun.security.provider;
+
+import jdk.crypto.jniprovider.NativeCrypto;
 
 public final class NativeSHA extends NativeDigest {
 
@@ -36,6 +38,6 @@ public final class NativeSHA extends NativeDigest {
      * Creates a new native SHA object.
      */
     public NativeSHA() {
-        super("SHA-1", 20, 0);
+        super("SHA-1", 20, NativeCrypto.SHA1_160);
     }
 }

--- a/closed/src/java.base/share/classes/sun/security/provider/NativeSHA2.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeSHA2.java
@@ -24,11 +24,13 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  */
 
 package sun.security.provider;
+
+import jdk.crypto.jniprovider.NativeCrypto;
 
 abstract class NativeSHA2 {
 
@@ -38,7 +40,7 @@ abstract class NativeSHA2 {
     public static final class SHA224 extends NativeDigest {
 
         public SHA224() {
-            super("SHA-224", 28, 2);
+            super("SHA-224", 28, NativeCrypto.SHA2_224);
         }
     }
 
@@ -48,7 +50,7 @@ abstract class NativeSHA2 {
     public static final class SHA256 extends NativeDigest {
 
         public SHA256() {
-            super("SHA-256", 32, 1);
+            super("SHA-256", 32, NativeCrypto.SHA2_256);
         }
     }
 }

--- a/closed/src/java.base/share/classes/sun/security/provider/NativeSHA5.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeSHA5.java
@@ -24,11 +24,13 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  */
 
 package sun.security.provider;
+
+import jdk.crypto.jniprovider.NativeCrypto;
 
 abstract class NativeSHA5 {
 
@@ -38,7 +40,7 @@ abstract class NativeSHA5 {
     public static final class SHA512 extends NativeDigest {
 
         public SHA512() {
-            super("SHA-512", 64, 4);
+            super("SHA-512", 64, NativeCrypto.SHA5_512);
         }
     }
 
@@ -48,7 +50,7 @@ abstract class NativeSHA5 {
     public static final class SHA384 extends NativeDigest {
 
         public SHA384() {
-            super("SHA-384", 48, 3);
+            super("SHA-384", 48, NativeCrypto.SHA5_384);
         }
     }
 }

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -27,6 +27,7 @@
 #include <openssl/err.h>
 #include <openssl/rsa.h>
 #include <openssl/ecdh.h>
+#include <openssl/pkcs12.h>
 
 #include <jni.h>
 #include <stdio.h>
@@ -134,6 +135,8 @@ typedef int OSSL_EC_KEY_set_public_key_t(EC_KEY *, const EC_POINT *);
 typedef int OSSL_EC_KEY_check_key_t(const EC_KEY *);
 typedef int EC_set_public_key_t(EC_KEY *, BIGNUM *, BIGNUM *, int);
 
+typedef int OSSL_PKCS12_key_gen_t(const char *, int, unsigned char *, int, int, int, int, unsigned char *, const EVP_MD *);
+
 typedef int OSSL_CRYPTO_num_locks_t();
 typedef void OSSL_CRYPTO_THREADID_set_numeric_t(CRYPTO_THREADID *id, unsigned long val);
 typedef void* OSSL_OPENSSL_malloc_t(size_t num);
@@ -234,6 +237,9 @@ OSSL_BN_CTX_free_t* OSSL_BN_CTX_free;
 OSSL_EC_KEY_set_public_key_t* OSSL_EC_KEY_set_public_key;
 OSSL_EC_KEY_check_key_t* OSSL_EC_KEY_check_key;
 EC_set_public_key_t* EC_set_public_key;
+
+/* Define pointers for OpenSSL functions to handle PBE algorithm. */
+OSSL_PKCS12_key_gen_t* OSSL_PKCS12_key_gen;
 
 /* Structure for OpenSSL Digest context. */
 typedef struct OpenSSLMDContext {
@@ -455,6 +461,9 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         OSSL_ECGF2M = JNI_TRUE;
     }
 
+    /* Load the functions symbols for OpenSSL PBE algorithm. */
+    OSSL_PKCS12_key_gen = (OSSL_PKCS12_key_gen_t*)find_crypto_symbol(crypto_library, "PKCS12_key_gen_uni");
+
     if ((NULL == OSSL_error_string) ||
         (NULL == OSSL_error_string_n) ||
         (NULL == OSSL_get_error) ||
@@ -513,6 +522,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         (NULL == OSSL_BN_CTX_free) ||
         (NULL == OSSL_EC_KEY_set_public_key) ||
         (NULL == OSSL_EC_KEY_check_key) ||
+        (NULL == OSSL_PKCS12_key_gen) ||
         /* Check symbols that are only available in OpenSSL 1.1.x and above */
         ((1 == ossl_ver) && ((NULL == OSSL_chacha20) || (NULL == OSSL_chacha20_poly1305))) ||
         /* Check symbols that are only available in OpenSSL 1.0.x and above */
@@ -703,19 +713,19 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateCon
     OpenSSLMDContext *context = NULL;
 
     switch (algoIdx) {
-        case 0:
+        case jdk_crypto_jniprovider_NativeCrypto_SHA1_160:
             digestAlg = (*OSSL_sha1)();
             break;
-        case 1:
-            digestAlg = (*OSSL_sha256)();
-            break;
-        case 2:
+        case jdk_crypto_jniprovider_NativeCrypto_SHA2_224:
             digestAlg = (*OSSL_sha224)();
             break;
-        case 3:
+        case jdk_crypto_jniprovider_NativeCrypto_SHA2_256:
+            digestAlg = (*OSSL_sha256)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA5_384:
             digestAlg = (*OSSL_sha384)();
             break;
-        case 4:
+        case jdk_crypto_jniprovider_NativeCrypto_SHA5_512:
             digestAlg = (*OSSL_sha512)();
             break;
         default:
@@ -2795,6 +2805,73 @@ setECPublicKey(EC_KEY *key, BIGNUM *x, BIGNUM *y, int field)
 
     if (1 == ret) {
         ret = (*OSSL_EC_KEY_check_key)(key);
+    }
+
+    return ret;
+}
+
+/* Password-based encryption algorithm.
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    PBEDerive
+ * Signature: (J[BI[BI[BIIII)I
+ */
+JNIEXPORT jint JNICALL
+Java_jdk_crypto_jniprovider_NativeCrypto_PBEDerive
+    (JNIEnv *env, jclass obj, jbyteArray password, jint passwordLength, jbyteArray salt, jint saltLength, jbyteArray key, jint iterations, jint n, jint id, jint hashAlgorithm)
+{
+    const EVP_MD *digestAlgorithm = NULL;
+    char *nativePassword = NULL;
+    unsigned char *nativeSalt = NULL;
+    unsigned char *nativeKey = NULL;
+    jint ret = -1;
+
+    switch (hashAlgorithm) {
+        case jdk_crypto_jniprovider_NativeCrypto_SHA1_160:
+            digestAlgorithm = (*OSSL_sha1)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA2_224:
+            digestAlgorithm = (*OSSL_sha224)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA2_256:
+            digestAlgorithm = (*OSSL_sha256)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA5_384:
+            digestAlgorithm = (*OSSL_sha384)();
+            break;
+        case jdk_crypto_jniprovider_NativeCrypto_SHA5_512:
+            digestAlgorithm = (*OSSL_sha512)();
+            break;
+        default:
+            goto cleanup;
+    }
+
+    nativePassword = (char*)((*env)->GetPrimitiveArrayCritical(env, password, 0));
+    if (NULL == nativePassword) {
+        goto cleanup;
+    }
+    nativeSalt = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, salt, 0));
+    if (NULL == nativeSalt) {
+        goto cleanup;
+    }
+    nativeKey = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, key, 0));
+    if (NULL == nativeKey) {
+        goto cleanup;
+    }
+
+    if (1 == (*OSSL_PKCS12_key_gen)(nativePassword, passwordLength, nativeSalt, saltLength, id, iterations, n, nativeKey, digestAlgorithm)) {
+        ret = 0;
+    }
+
+cleanup:
+    if (NULL != nativePassword) {
+        (*env)->ReleasePrimitiveArrayCritical(env, password, nativePassword, JNI_ABORT);
+    }
+    if (NULL != nativeSalt) {
+        (*env)->ReleasePrimitiveArrayCritical(env, salt, nativeSalt, JNI_ABORT);
+    }
+    if (NULL != nativeKey) {
+        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, JNI_ABORT);
     }
 
     return ret;

--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
@@ -55,7 +55,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.util.ECUtil;
 import sun.security.util.NamedCurve;
 
@@ -65,7 +64,7 @@ import sun.security.util.NamedCurve;
 public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
 
     private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
-    private static final String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 
     /* false if OPENSSL_NO_EC2M is defined, true otherwise */
     private static final boolean nativeGF2m = nativeCrypto.ECNativeGF2m();
@@ -126,7 +125,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
 
             if ((!nativeGF2m) && this.privateKey.isECFieldF2m()) {
                 /* only print the first time a curve is used */
-                if ((curveSupported.putIfAbsent("EC2m", Boolean.FALSE) == null) && (nativeCryptTrace != null)) {
+                if ((curveSupported.putIfAbsent("EC2m", Boolean.FALSE) == null) && nativeCryptTrace) {
                     System.err.println("EC2m is not supported by OpenSSL, using Java crypto implementation.");
                 }
                 this.initializeJavaImplementation(key, random);
@@ -136,7 +135,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
                 this.javaImplementation = null;
             }
         } else {
-            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && (nativeCryptTrace != null)) {
+            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && nativeCryptTrace) {
                 System.err.println("Only ECPrivateKeyImpl and ECPublicKeyImpl are supported by the native implementation,"
                         + " using Java crypto implementation.");
             }
@@ -184,7 +183,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
 
             return null;
         } else {
-            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && (nativeCryptTrace != null)) {
+            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && nativeCryptTrace) {
                 System.err.println("Only ECPrivateKeyImpl and ECPublicKeyImpl are supported by the native implementation,"
                         + " using Java crypto implementation.");
             }
@@ -228,7 +227,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
             if (curveSupported.putIfAbsent(this.curve, Boolean.FALSE) != null) {
                 throw new ProviderException("Could not convert keys to native format");
             }
-            if (nativeCryptTrace != null) {
+            if (nativeCryptTrace) {
                 System.err.println(this.curve + " is not supported by OpenSSL, using Java crypto implementation.");
             }
             try {
@@ -240,7 +239,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
             }
             return this.javaImplementation.engineGenerateSecret(sharedSecret, offset);
         }
-        if ((curveSupported.putIfAbsent(this.curve, Boolean.TRUE) == null) && (nativeCryptTrace != null)) {
+        if ((curveSupported.putIfAbsent(this.curve, Boolean.TRUE) == null) && nativeCryptTrace) {
             System.err.println(this.curve + " is supported by OpenSSL, using native crypto implementation.");
         }
         int ret;

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -61,20 +61,10 @@ import jdk.crypto.jniprovider.NativeCrypto;
 
 final class CipherCore {
 
-    /*
-     * Check whether native crypto is disabled with property.
-     *
-     * By default, the native crypto is enabled and uses the native
-     * crypto library implementation.
-     *
-     * The property 'jdk.nativeCBC' is used to disable Native CBC alone,
-     * 'jdk.nativeGCM' is used to disable Native GCM alone and
-     * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC, GCM, RSA, ChaCha20, and EC).
+    /* The property 'jdk.nativeCBC' is used to control enablement of the native
+     * CBC implementation.
      */
-    private static boolean useNativeCrypto = true;
-    private static boolean useNativeCBC = true;
-    private static boolean useNativeGCM = true;
+    private static final boolean useNativeCBC = NativeCrypto.isAlgorithmEnabled("jdk.nativeCBC", "CipherCore");
 
     /*
      * internal buffer
@@ -1105,56 +1095,6 @@ final class CipherCore {
                     wrappedKeyType);
         } finally {
             Arrays.fill(encodedKey, (byte)0);
-        }
-    }
-    private static String privilegedGetProperty(final String property) {
-        return AccessController.doPrivileged(new PrivilegedAction<String>() {
-            public String run() {
-                return System.getProperty(property);
-            }
-        });
-    }
-
-    static {
-        String nativeCryptTrace = privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr   = privilegedGetProperty("jdk.nativeCrypto");
-        String nativeCBCStr     = privilegedGetProperty("jdk.nativeCBC");
-        String nativeGCMStr     = privilegedGetProperty("jdk.nativeGCM");
-
-        useNativeCrypto = (nativeCryptStr == null) || Boolean.parseBoolean(nativeCryptStr);
-
-        if (!useNativeCrypto) {
-            useNativeCBC = false;
-            useNativeGCM = false;
-        } else {
-            useNativeCBC = (nativeCBCStr == null) || Boolean.parseBoolean(nativeCBCStr);
-            useNativeGCM = (nativeGCMStr == null) || Boolean.parseBoolean(nativeGCMStr);
-        }
-
-        if (useNativeCBC || useNativeGCM) {
-            /*
-             * User want to use native crypto implementation.
-             * Make sure the native crypto libraries are loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeCBC = false;
-                useNativeGCM = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("CipherCore Load - using native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-                System.err.println("CipherCore Load - native crypto library disabled.");
-            }
         }
     }
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/PKCS12PBECipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PKCS12PBECipherCore.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
 
 package com.sun.crypto.provider;
 
@@ -33,6 +38,7 @@ import java.util.Arrays;
 import javax.crypto.*;
 import javax.crypto.spec.*;
 import javax.security.auth.DestroyFailedException;
+import jdk.crypto.jniprovider.NativeCrypto;
 
 /**
  * This class implements password-base encryption algorithm with
@@ -54,6 +60,12 @@ final class PKCS12PBECipherCore {
 
     private static final int DEFAULT_SALT_LENGTH = 20;
     private static final int DEFAULT_COUNT = 1024;
+    private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
+    /* The property 'jdk.nativePBE' is used to control enablement of the native
+     * PBE implementation.
+     */
+    private static final boolean useNativePBE = NativeCrypto.isAlgorithmEnabled("jdk.nativePBE", "PKCS12PBECipherCore");
 
     static final int CIPHER_KEY = 1;
     static final int CIPHER_IV = 2;
@@ -85,6 +97,33 @@ final class PKCS12PBECipherCore {
             passwd[j+1] = (byte) (chars[i] & 0xFF);
         }
         byte[] key = new byte[n];
+
+        if (useNativePBE) {
+            boolean hashSupported = true;
+            int hashIndex = 0;
+            if (hashAlgo.equals("SHA") || hashAlgo.equals("SHA1") || hashAlgo.equals("SHA-1")) {
+                hashIndex = NativeCrypto.SHA1_160;
+            } else if (hashAlgo.equals("SHA224") || hashAlgo.equals("SHA-224")) {
+                hashIndex = NativeCrypto.SHA2_224;
+            } else if (hashAlgo.equals("SHA256") || hashAlgo.equals("SHA-256")) {
+                hashIndex = NativeCrypto.SHA2_256;
+            } else if (hashAlgo.equals("SHA384") || hashAlgo.equals("SHA-384")) {
+                hashIndex = NativeCrypto.SHA5_384;
+            } else if (hashAlgo.equals("SHA512") || hashAlgo.equals("SHA-512")) {
+                hashIndex = NativeCrypto.SHA5_512;
+            } else {
+                hashSupported = false;
+            }
+            if (hashSupported) {
+                if (nativeCrypto.PBEDerive(passwd, passwd.length, salt, salt.length, key, ic, n, type, hashIndex) != -1) {
+                    return key;
+                } else if (nativeCryptTrace) {
+                    System.err.println("Native PBE derive failed for algorithm " + hashAlgo + ", using Java implementation.");
+                }
+            } else if (nativeCryptTrace) {
+                System.err.println("The algorithm " + hashAlgo + " is not supported in native code, using Java implementation.");
+            }
+        }
 
         try {
             MessageDigest sha = MessageDigest.getInstance(hashAlgo);

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -87,127 +87,16 @@ import sun.security.action.GetPropertyAction;
 
 public final class SunJCE extends Provider {
 
-    /*
-     * Check system properties to see whether native crypto should be enabled.
-     * By default, the native crypto is enabled and uses the native library.
-     * The property 'jdk.nativeChaCha20' is used to control native ChaCha20 alone
-     * and 'jdk.nativeCrypto' is used to control all native crypto implementations
-     * (Digest, CBC, GCM, ChaCha20, and EC).
+    /* The property 'jdk.nativeChaCha20' is used to control enablement of the native
+     * ChaCha20 implementation. ChaCha20 is only supported in OpenSSL 1.1.0 and above.
      */
-    private static final boolean useNativeChaCha20Cipher = nativeChaCha20Init();
+    private static final boolean useNativeChaCha20Cipher = NativeCrypto.isAlgorithmEnabled("jdk.nativeChaCha20",
+            "NativeChaCha20Cipher", NativeCrypto.getVersion() >= 1, "Need OpenSSL 1.1.0 or above for ChaCha20 support.");
 
-    /*
-     * Check system properties to see whether native crypto should be enabled.
-     * By default, the native crypto is enabled and uses the native library.
-     * The property 'jdk.nativeGCM' is used to control native GCM alone
-     * and 'jdk.nativeCrypto' is used to control all native crypto implementations
-     * (Digest, CBC, GCM, and ChaCha20).
+    /* The property 'jdk.nativeGCM' is used to control enablement of the native
+     * GCM implementation.
      */
-    private static final boolean useNativeGaloisCounterMode = nativeGCMInit();
-
-    private static boolean nativeChaCha20Init() {
-        boolean nativeChaCha20 = true;
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-
-        if ((nativeCryptStr != null) && !Boolean.parseBoolean(nativeCryptStr)) {
-            /* nativeCrypto is explicitly disabled */
-            nativeChaCha20 = false;
-        } else {
-            String nativeChaCha20Str = GetPropertyAction.privilegedGetProperty("jdk.nativeChaCha20");
-
-            if ((nativeChaCha20Str != null) && !Boolean.parseBoolean(nativeChaCha20Str)) {
-                /* nativeChaCha20 is explicitly disabled */
-                nativeChaCha20 = false;
-            }
-        }
-
-        if (!nativeChaCha20) {
-            if (nativeCryptTrace != null) {
-                System.err.println("NativeChaCha20Cipher load - Native crypto library disabled.");
-            }
-        } else {
-            /*
-             * User wants to use the native crypto implementation.
-             * Make sure the native crypto library is loaded successfully.
-             * Otherwise, issue a warning message and fall back to the built-in
-             * java crypto implementation.
-             *
-             * ChaCha20 is only supported in OpenSSL 1.1.0 and above.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                nativeChaCha20 = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                final int ossl_ver = NativeCrypto.getVersion();
-
-                if (ossl_ver < 1) {
-                    nativeChaCha20 = false;
-
-                    if (nativeCryptTrace != null) {
-                        System.err.println("Warning: Native ChaCha20 load failed." +
-                                " Need OpenSSL 1.1.0 or above for ChaCha20 support." +
-                                " Using Java crypto implementation");
-                    }
-                } else {
-                    if (nativeCryptTrace != null) {
-                        System.err.println("NativeChaCha20Cipher load - using Native crypto library.");
-                    }
-                }
-            }
-        }
-
-        return nativeChaCha20;
-    }
-
-    private static boolean nativeGCMInit() {
-        boolean nativeGCM = true;
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-
-        if ((nativeCryptStr != null) && !Boolean.parseBoolean(nativeCryptStr)) {
-            /* nativeCrypto is explicitly disabled */
-            nativeGCM = false;
-        } else {
-            String nativeGCMStr = GetPropertyAction.privilegedGetProperty("jdk.nativeGCM");
-
-            if ((nativeGCMStr != null) && !Boolean.parseBoolean(nativeGCMStr)) {
-                /* nativeGCM is explicitly disabled */
-                nativeGCM = false;
-            }
-        }
-
-        if (!nativeGCM) {
-            if (nativeCryptTrace != null) {
-                System.err.println("NativeGaloisCounterMode load - Native crypto library disabled.");
-            }
-        } else {
-            /*
-             * User wants to use the native crypto implementation.
-             * Make sure the native crypto library is loaded successfully.
-             * Otherwise, issue a warning message and fall back to the built-in
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                nativeGCM = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("NativeGaloisCounterMode load - using Native crypto library.");
-                }
-            }
-        }
-
-        return nativeGCM;
-    }
+    private static final boolean useNativeGaloisCounterMode = NativeCrypto.isAlgorithmEnabled("jdk.nativeGCM", "NativeGaloisCounterMode");
 
     @java.io.Serial
     private static final long serialVersionUID = 6812507587804302833L;

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -92,14 +92,10 @@ import openj9.internal.security.FIPSConfigurator;
 
 public final class SunEntries {
 
-    /*
-     * Check whether native crypto is enabled with property.
-     * By default, the native crypto is enabled  and uses native library crypto.
-     * The property 'jdk.nativeDigest' is used to disable Native digest alone
-     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC, GCM, RSA, ChaCha20, and EC).
+    /* The property 'jdk.nativeDigest' is used to control enablement of the native
+     * digest implementation.
      */
-    private static boolean useNativeDigest = true;
+    private static final boolean useNativeDigest = NativeCrypto.isAlgorithmEnabled("jdk.nativeDigest", "MessageDigest");
 
     // the default algo used by SecureRandom class for new SecureRandom() calls
     public static final String DEF_SECURE_RANDOM_ALGO;
@@ -431,46 +427,4 @@ public final class SunEntries {
             return new File(device.getPath());
         }
     }
-
-    static {
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-        String nativeDigestStr = GetPropertyAction.privilegedGetProperty("jdk.nativeDigest");
-
-        if (Boolean.parseBoolean(nativeCryptStr) || nativeCryptStr == null) {
-            /* nativeCrypto is enabled */
-            if (!(Boolean.parseBoolean(nativeDigestStr) || nativeDigestStr == null)) {
-                useNativeDigest = false;
-            }
-        } else {
-            /* nativeCrypto is disabled */
-            useNativeDigest = false;
-        }
-
-        if (useNativeDigest) {
-            /*
-             * User want to use native crypto implementation.
-             * Make sure the native crypto libraries are loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeDigest = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("MessageDigest load - using Native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-                System.err.println("MessageDigest load - Native crypto library disabled.");
-            }
-        }
-    }
-
 }

--- a/src/java.base/share/classes/sun/security/rsa/RSACore.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSACore.java
@@ -32,7 +32,6 @@ package sun.security.rsa;
 
 import sun.security.jca.JCAUtil;
 
-import sun.security.action.GetPropertyAction;
 import jdk.crypto.jniprovider.NativeCrypto;
 
 import javax.crypto.BadPaddingException;
@@ -63,17 +62,10 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public final class RSACore {
 
-    /*
-     * Check whether native crypto is enabled with property.
-     *
-     * By default, the native crypto is enabled and uses the native
-     * crypto library implementation.
-     *
-     * The property 'jdk.nativeRSA' is used to enable Native RSA alone,
-     * and 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
-     * CBC, GCM, and RSA, and EC).
+    /* The property 'jdk.nativeRSA' is used to control enablement of the native
+     * RSA implementation.
      */
-    private static boolean useNativeRsa = true;
+    private static boolean useNativeRsa = NativeCrypto.isAlgorithmEnabled("jdk.nativeRSA", "RSACore");
 
     // globally enable/disable use of blinding
     private static final boolean ENABLE_BLINDING = true;
@@ -282,48 +274,6 @@ public final class RSACore {
         System.arraycopy(b, 0, t, (len - n), n);
         Arrays.fill(b, (byte)0);
         return t;
-    }
-
-    static {
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-
-        if ((nativeCryptStr != null) && !Boolean.parseBoolean(nativeCryptStr)) {
-            /* nativeCrypto is disabled */
-            useNativeRsa = false;
-        } else {
-            String nativeRsaStr = GetPropertyAction.privilegedGetProperty("jdk.nativeRSA");
-
-            if ((nativeRsaStr != null) && !Boolean.parseBoolean(nativeRsaStr)) {
-                /* nativeRSA is disabled */
-                useNativeRsa = false;
-            }
-        }
-
-        if (useNativeRsa) {
-            /*
-             * User wants to use native crypto implementation.
-             * Make sure the native crypto libraries are loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeRsa = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("RSACore load - using Native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-                System.err.println("RSACore load - Native crypto library disabled.");
-            }
-        }
     }
 
     /**

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -46,8 +46,6 @@ import java.util.List;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
-import sun.security.action.GetPropertyAction;
-import sun.security.ec.ed.EdDSAAlgorithmParameters;
 import sun.security.ec.ed.EdDSAKeyFactory;
 import sun.security.ec.ed.EdDSAKeyPairGenerator;
 import sun.security.ec.ed.EdDSASignature;
@@ -67,19 +65,10 @@ public final class SunEC extends Provider {
 
     private static final long serialVersionUID = -2279741672933606418L;
 
-    /*
-     * Check whether native crypto is disabled with property.
-     *
-     * By default, the native crypto is enabled and uses the native
-     * crypto library implementation.
-     *
-     * The property 'jdk.nativeEC' is used to disable Native EC alone and
-     * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC, GCM, RSA, ChaCha20, and EC).
+    /* The property 'jdk.nativeEC' is used to control enablement of the native
+     * EC implementation.
      */
-    private static boolean useNativeCrypto;
-
-    private static boolean useNativeEC;
+    private static final boolean useNativeEC = NativeCrypto.isAlgorithmEnabled("jdk.nativeEC", "SunEC");
 
     private static class ProviderServiceA extends ProviderService {
         ProviderServiceA(Provider p, String type, String algo, String cn,
@@ -427,44 +416,5 @@ public final class SunEC extends Provider {
         putService(new ProviderServiceA(this, "Signature",
             "Ed448", "sun.security.ec.ed.EdDSASignature.Ed448", ATTRS));
 
-    }
-
-    static {
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr   = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-        String nativeECStr      = GetPropertyAction.privilegedGetProperty("jdk.nativeEC");
-
-        useNativeCrypto = (nativeCryptStr == null) || Boolean.parseBoolean(nativeCryptStr);
-
-        if (!useNativeCrypto) {
-            useNativeEC = false;
-        } else {
-            useNativeEC = (nativeECStr == null) || Boolean.parseBoolean(nativeECStr);
-        }
-
-        if (useNativeEC) {
-            /*
-             * User wants to use the native crypto implementation.
-             * Make sure the native crypto library is loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeEC = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("SunEC Load - using native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-                System.err.println("SunEC Load - native crypto library disabled.");
-            }
-        }
     }
 }


### PR DESCRIPTION
Porting PR [openj9-openjdk-jdk11#585](https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/585)

Signed-off-by: Zainab Fatmi <zainab@ibm.com>