### PR TITLE
Set interrupt field before native call

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1755,8 +1755,8 @@ public class Thread implements Runnable {
         }
 
         synchronized (interruptLock) {
-            interrupt0();  // inform VM of interrupt
             interrupted = true;
+            interrupt0();  // inform VM of interrupt
 
             // thread may be blocked in an I/O operation
             Interruptible b = nioBlocker;


### PR DESCRIPTION
Set interrupt field before native call

There is a potential race if the interrupt field is set after the interrupt call where another thread may query interrupt status before the field is set.

Fixes: https://github.com/eclipse-openj9/openj9/issues/16174

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>