### PR TITLE
Fix Thread.getStackTrace synchronization

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -2571,6 +2571,10 @@ public class Thread implements Runnable {
     private Object getStackTrace0() {
         Throwable t;
         synchronized (interruptLock) {
+            /* Ensure only live thread is passed to native code. */
+            if (!isAlive()) {
+                return EMPTY_STACK_TRACE;
+            }
             t = getStackTraceImpl();
         }
         return (Object)J9VMInternals.getStackTrace(t, false);


### PR DESCRIPTION
Add extra check in getStackTrace0 under interruptLock to ensure only live thread is passed to native code.

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>