### PR TITLE
Add synchronized block in getAndClearInterrupt()

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1813,15 +1813,14 @@ public class Thread implements Runnable {
     }
 
     boolean getAndClearInterrupt() {
-        boolean oldValue = interrupted;
-        // We may have been interrupted the moment after we read the field,
-        // so only clear the field if we saw that it was set and will return
-        // true; otherwise we could lose an interrupt.
-        if (oldValue) {
-            interrupted = false;
-            clearInterruptEvent();
+        synchronized (interruptLock) {
+            boolean oldValue = interrupted;
+            if (oldValue) {
+                interrupted = false;
+                clearInterruptEvent();
+            }
+            return oldValue;
         }
-        return oldValue;
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/15465

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>