### PR TITLE
Port CRIU related PRs from openj9-openjdk-jdk17 and handle thread interrupted status at CRIU single threaded mode

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -52,6 +52,8 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
 		src/java.base/share/classes/java/security/Security.java \
+		src/java.base/share/classes/java/util/Timer.java \
+		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 

--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,9 +51,12 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	SRC := $(TOPDIR), \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
+		src/java.base/share/classes/java/lang/ClassValue.java \
+		src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java \
 		src/java.base/share/classes/java/security/Security.java \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
+		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 

--- a/closed/src/java.base/share/classes/openj9/internal/criu/CRIUSECProvider.java
+++ b/closed/src/java.base/share/classes/openj9/internal/criu/CRIUSECProvider.java
@@ -57,7 +57,8 @@ public final class CRIUSECProvider extends Provider {
     /**
      * Resets the security digests.
      */
-    public static void resetDigests() {
+    public static void resetCRIUSEC() {
+        NativePRNG.clearRNGState();
         DigestBase.resetDigests();
     }
 }

--- a/closed/src/java.base/share/classes/openj9/internal/criu/SHA1PRNG.java
+++ b/closed/src/java.base/share/classes/openj9/internal/criu/SHA1PRNG.java
@@ -1,0 +1,200 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*
+ * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package openj9.internal.criu;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.Arrays;
+
+/**
+ * <p>This class provides a crytpographically strong pseudo-random number
+ * generator based on the SHA-1 hash algorithm.
+ *
+ * <p>Seed must be provided externally.
+ *
+ * <p>Also note that when a random object is deserialized,
+ * <a href="#engineNextBytes(byte[])">engineNextBytes</a> invoked on the
+ * restored random object will yield the exact same (random) bytes as the
+ * original object.  If this behaviour is not desired, the restored random
+ * object should be seeded, using
+ * <a href="#engineSetSeed(byte[])">engineSetSeed</a>.
+ *
+ * @author Benjamin Renaud
+ * @author Josh Bloch
+ * @author Gadi Guy
+ */
+
+public final class SHA1PRNG implements java.io.Serializable {
+
+    private static final long serialVersionUID = 3581829991155417889L;
+
+    // SHA-1 Digest yields 160-bit hashes which require 20 bytes of space.
+    private static final int DIGEST_SIZE = 20;
+    private transient MessageDigest digest;
+    private byte[] state;
+    private byte[] remainder;
+    private int remCount;
+
+    // This class is a modified version of the SHA1PRNG SecureRandom implementation
+    // that is found at sun.security.provider.SecureRandom.
+    // It was modified to be used by CRIUSEC NativePRNG as a mixing data source.
+    // Auto-seeding was removed, it is always seeded by NativePRNG from a
+    // blocking entropy source.
+
+    private SHA1PRNG(byte[] seed) {
+        init(seed);
+    }
+
+    static SHA1PRNG seedFrom(InputStream in) throws IOException {
+        byte[] seed = new byte[DIGEST_SIZE];
+        if (in.readNBytes(seed, 0, DIGEST_SIZE) != DIGEST_SIZE) {
+            throw new IOException("Could not read seed");
+        }
+        return new SHA1PRNG(seed);
+    }
+
+    /**
+     * This call, used by the constructor, instantiates the SHA digest
+     * and sets the seed.
+     */
+    private void init(byte[] seed) {
+        if (seed == null) {
+            throw new InternalError("internal error: no seed available.");
+        }
+
+        try {
+            digest = MessageDigest.getInstance("SHA-1", "CRIUSEC");
+        } catch (NoSuchProviderException | NoSuchAlgorithmException e) {
+            throw new InternalError("internal error: SHA-1 not available.", e);
+        }
+
+        engineSetSeed(seed);
+    }
+
+
+    /**
+     * Reseeds this random object. The given seed supplements, rather than
+     * replaces, the existing seed. Thus, repeated calls are guaranteed
+     * never to reduce randomness.
+     *
+     * @param seed the seed.
+     */
+    public synchronized void engineSetSeed(byte[] seed) {
+        if (state != null) {
+            digest.update(state);
+            for (int i = 0; i < state.length; i++) {
+                state[i] = 0;
+            }
+        }
+        state = digest.digest(seed);
+        remCount = 0;
+    }
+
+    private static void updateState(byte[] state, byte[] output) {
+        int carry = 1;
+        boolean collision = true;
+
+        // state(n + 1) = (state(n) + output(n) + 1) % 2^160;
+        for (int i = 0; i < state.length; i++) {
+            // Add two bytes.
+            int stateCalc = (state[i] & 0xFF) + (output[i] & 0xFF) + carry;
+            // Result is lower 8 bits.
+            byte newState = (byte)stateCalc;
+            // Store result. Check for state collision.
+            collision &= (state[i] == newState);
+            state[i] = newState;
+            // High 8 bits are carry. Store for next iteration.
+            carry = stateCalc >>> 8;
+        }
+
+        // Make sure at least one bit changes.
+        if (collision) {
+           state[0]++;
+        }
+    }
+
+
+    /**
+     * Generates a user-specified number of random bytes.
+     *
+     * @param result the array to be filled in with random bytes.
+     */
+    public synchronized void engineNextBytes(byte[] result) {
+        int index = 0;
+        byte[] output = remainder;
+
+        // Use remainder from last time.
+        int r = remCount;
+        if (r > 0) {
+            // Compute how many bytes to be copied.
+            int todo = Math.min(result.length - index, DIGEST_SIZE - r);
+            // Copy the bytes, zero the buffer.
+            for (int i = 0; i < todo; i++) {
+                result[i] = output[r];
+                output[r++] = 0;
+            }
+            remCount += todo;
+            index += todo;
+        }
+
+        // If we need more bytes, make them.
+        while (index < result.length) {
+            // Step the state.
+            digest.update(state);
+            output = digest.digest();
+            updateState(state, output);
+
+            // Compute how many bytes to be copied.
+            int todo = Math.min(result.length - index, DIGEST_SIZE);
+            // Copy the bytes, zero the buffer.
+            for (int i = 0; i < todo; i++) {
+                result[index++] = output[i];
+                output[i] = 0;
+            }
+            remCount += todo;
+        }
+
+        // Store remainder for next time.
+        remainder = output;
+        remCount %= DIGEST_SIZE;
+    }
+
+    void clearState() {
+        Arrays.fill(state, (byte) 0x00);
+        Arrays.fill(remainder, (byte) 0x00);
+        remCount = 0;
+    }
+}

--- a/make/modules/java.base/gensrc/GensrcCharsetMapping.gmk
+++ b/make/modules/java.base/gensrc/GensrcCharsetMapping.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
+
 ################################################################################
 #
 # Generate StandardCharsets.java and individul sun.nio.cs charset class using
@@ -40,6 +44,26 @@ CHARSET_STANDARD_JAVA_TEMPLATES := \
     $(TOPDIR)/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
 CHARSET_STANDARD_OS := stdcs-$(OPENJDK_TARGET_OS)
 
+J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
+JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
+JPP_TAGS    := PLATFORM-$(OPENJ9_PLATFORM_CODE)
+
+define RunJPP
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-config $1 \
+			-baseDir "$(call FixPath,$(dir $2))" \
+			-srcRoot $(notdir $2)/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
+			-dest "$(call FixPath,$(SUPPORT_OUTPUTDIR)$(strip $3))" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))" \
+			-includeIfUnsure \
+			-noWarnIncludeIf
+endef # RunJPP
+
 $(CHARSET_DONE_BASE)-stdcs: $(CHARSET_DATA_DIR)/charsets \
     $(wildcard $(CHARSET_DATA_DIR)/$(CHARSET_STANDARD_OS)) \
     $(CHARSET_TEMPLATES) $(CHARSET_STANDARD_JAVA_TEMPLATES) \
@@ -51,6 +75,10 @@ $(CHARSET_DONE_BASE)-stdcs: $(CHARSET_DATA_DIR)/charsets \
 	    $(CHARSET_STANDARD_JAVA_TEMPLATES) $(CHARSET_EXTSRC_DIR) \
 	    $(CHARSET_COPYRIGHT_HEADER) \
             $(LOG_DEBUG)
+	$(MKDIR) -p $(SUPPORT_OUTPUTDIR)/overlay-gensrc/src/java.base/sun/nio/cs
+	$(CP) $(CHARSET_GENSRC_JAVA_DIR_BASE)/StandardCharsets.java $(SUPPORT_OUTPUTDIR)/overlay-gensrc/src/java.base/sun/nio/cs/
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay-gensrc, /overlay-result)
+	$(CP) $(SUPPORT_OUTPUTDIR)/overlay-result/java.base/sun/nio/cs/StandardCharsets.java $(CHARSET_GENSRC_JAVA_DIR_BASE)/
 	$(TOUCH) '$@'
 
 TARGETS += $(CHARSET_DONE_BASE)-stdcs

--- a/src/java.base/share/classes/java/lang/ClassValue.java
+++ b/src/java.base/share/classes/java/lang/ClassValue.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang;
 
 import java.util.WeakHashMap;
@@ -33,6 +39,10 @@ import jdk.internal.misc.Unsafe;
 
 import static java.lang.ClassValue.ClassValueMap.probeHomeLocation;
 import static java.lang.ClassValue.ClassValueMap.probeBackupLocations;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * Lazily associate a computed value with (potentially) every type.
@@ -373,6 +383,9 @@ public abstract class ClassValue<T> {
 
     private static final Object CRITICAL_SECTION = new Object();
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private static ClassValueMap initializeMap(Class<?> type) {
         ClassValueMap map;
         synchronized (CRITICAL_SECTION) {  // private object to avoid deadlocks

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1793,6 +1793,10 @@ public class Thread implements Runnable {
      * @revised 6.0, 14
      */
     public boolean isInterrupted() {
+        // use fully qualified name to avoid ambiguous class error
+        if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
+            return isInterruptedImpl();
+        }
         return interrupted;
     }
 
@@ -1813,6 +1817,10 @@ public class Thread implements Runnable {
     }
 
     boolean getAndClearInterrupt() {
+        // use fully qualified name to avoid ambiguous class error
+        if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
+            return interruptedImpl();
+        }
         synchronized (interruptLock) {
             boolean oldValue = interrupted;
             if (oldValue) {
@@ -3180,6 +3188,7 @@ public class Thread implements Runnable {
     private native void resumeImpl();
     private native void interruptImpl();
     private static native boolean interruptedImpl();
+    private native boolean isInterruptedImpl();
     private native void setNameImpl(long threadRef, String threadName);
     private native int getStateImpl(long eetop);
 

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.access.SharedSecrets;
@@ -52,6 +58,10 @@ import static java.lang.invoke.MethodHandleNatives.Constants.REF_putStatic;
 import static java.lang.invoke.MethodHandleStatics.*;
 import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * Class specialization code.
@@ -159,6 +169,9 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
         }
     };
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public final S findSpecies(K key) {
         // Note:  Species instantiation may throw VirtualMachineError because of
         // code cache overflow.  If this happens the species bytecode may be

--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -214,7 +214,9 @@ public class Timer {
             throw new IllegalArgumentException("Negative delay.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/
@@ -275,7 +277,9 @@ public class Timer {
             throw new IllegalArgumentException("Non-positive period.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/
@@ -361,7 +365,9 @@ public class Timer {
             throw new IllegalArgumentException("Non-positive period.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/

--- a/src/java.base/share/classes/java/util/TimerTask.java
+++ b/src/java.base/share/classes/java/util/TimerTask.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util;
 
 /**
@@ -83,6 +89,13 @@ public abstract class TimerTask implements Runnable {
      * A value of 0 indicates a non-repeating task.
      */
     long period = 0;
+
+    /*[IF CRIU_SUPPORT]*/
+    /**
+     * Determine if the nextExecutionTime is to be adjusted.
+     */
+    boolean criuAdjustRequired;
+    /*[ENDIF] CRIU_SUPPORT*/
 
     /**
      * Creates a new timer task.

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -33,6 +33,12 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.concurrent;
 
 import java.io.ObjectStreamField;
@@ -69,6 +75,10 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import jdk.internal.misc.Unsafe;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * A hash table supporting full concurrency of retrievals and
@@ -1688,6 +1698,9 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @throws RuntimeException or Error if the mappingFunction does so,
      *         in which case the mapping is left unestablished
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
         if (key == null || mappingFunction == null)
             throw new NullPointerException();

--- a/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
+++ b/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
@@ -25,6 +25,12 @@
  *
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 // -- This file was mechanically generated: Do not edit! -- //
 
 package sun.nio.cs;
@@ -35,6 +41,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import jdk.internal.vm.annotation.Stable;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 public class StandardCharsets extends CharsetProvider {
 
@@ -165,6 +175,9 @@ public class StandardCharsets extends CharsetProvider {
         return cs;
     }
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public final Charset charsetForName(String charsetName) {
         synchronized (this) {
             return lookup(charsetName);


### PR DESCRIPTION
Cherry-pick CRIU related PRs from [openj9-openjdk-jdk17](https://github.com/ibmruntimes/openj9-openjdk-jdk17)
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/110
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/111
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/128

Note: following PRs have already been ported
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/84
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/87 which was cherry-pick of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/486 & https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/498

Added [Handle thread interrupted status at CRIU single threaded mode](https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/54/commits/c569e9e8668deb5e8a6f5b556c4912c834282611) to address delayed `Thread.interrupt()` at CRIU single threaded mode.

depends on https://github.com/eclipse-openj9/openj9/pull/16470

Signed-off-by: Jason Feng <fengj@ca.ibm.com>