### PR TITLE
Add OpenJ9PropsExt properties for docker.support

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
 
         Map<String, String> map = new HashMap<>();
         try {
+            map.put("docker.support", "true");
             map.put("vm.bits", vmBits());
             map.put("vm.cds", "false");
             map.put("vm.compiler2.enabled", "false");


### PR DESCRIPTION
Add `OpenJ9PropsExt` properties for `docker.support`

[A personal build](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/30364/console) w/ this PR passed most of sub-tests except 
```
15:57:16  java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.Metrics.getCpuSetMems()" because the return value of "jdk.internal.platform.Metrics.systemMetrics()" is null
15:57:16  	at TestDockerCpuMetrics.main(TestDockerCpuMetrics.java:80)
15:57:16  	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
15:57:16  	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
15:57:16  	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
15:57:16  	at java.base/java.lang.Thread.run(Thread.java:1573)
```
Related `jdk_container_0` issue - https://github.com/eclipse-openj9/openj9/issues/16505

Will port to JDK Next repo.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>