### PR TITLE
Remove unused OPENJDK_THREAD_SUPPORT & J9VM_OPT_OPENJDK_THREAD_SUPPORT

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -36,7 +36,7 @@ ifeq (true,$(OPENJ9_ENABLE_DDR))
   JppSourceDirs += $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
 endif # OPENJ9_ENABLE_DDR
 
-JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE) OPENJDK_THREAD_SUPPORT
+JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
 
 ifeq (true,$(OPENJ9_ENABLE_CRIU_SUPPORT))
   JPP_TAGS += CRIU_SUPPORT

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -438,7 +438,6 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 
   CMAKE_ARGS += -DJ9VM_OPT_METHOD_HANDLE=OFF
   CMAKE_ARGS += -DJ9VM_OPT_OPENJDK_METHODHANDLE=ON
-  CMAKE_ARGS += -DJ9VM_OPT_OPENJDK_THREAD_SUPPORT=ON
 
   # Propagate configure option '--disable-warnings-as-errors-omr' to OMR.
   ifeq (false,$(WARNINGS_AS_ERRORS_OMR))


### PR DESCRIPTION
Remove unused `OPENJDK_THREAD_SUPPORT` & `J9VM_OPT_OPENJDK_THREAD_SUPPORT`

As per https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/175#discussion_r1063802489
This is to be ported to JDK20+ extension repos.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>