### PR TITLE
Remove reference to opt_openjdkThreadSupport

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -277,9 +277,6 @@ endif # OPENJ9_ENABLE_CRIU_SUPPORT
 FEATURE_SED_SCRIPT += $(call SedDisable,opt_methodHandle)
 FEATURE_SED_SCRIPT += $(call SedEnable,opt_openjdkMethodhandle)
 
-# Adjust OpenJDK thread support enablement flags.
-FEATURE_SED_SCRIPT += $(call SedEnable,opt_openjdkThreadSupport)
-
 # Disable windows rebase.
 SPEC_SED_SCRIPT += $(call SedDisable,uma_windowsRebase)
 


### PR DESCRIPTION
That flag was removed by eclipse-openj9/openj9#16529.

This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/541.