### PR TITLE
Fix LoadLibraryUnloadTest

### DIFF
--- a/test/jdk/java/io/ObjectStreamClass/TestOSCClassLoaderLeak.java
+++ b/test/jdk/java/io/ObjectStreamClass/TestOSCClassLoaderLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,8 @@ import java.io.ObjectStreamField;
 import java.io.Serializable;
 import java.util.Arrays;
 import org.testng.annotations.Test;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
 
 import jdk.test.lib.util.ForceGC;
 
@@ -54,15 +54,14 @@ public class TestOSCClassLoaderLeak {
         objectStreamClass_MemoryLeakExample.toString();
 
         WeakReference<Object> myOwnClassLoaderWeakReference = new WeakReference<>(myOwnClassLoader);
-        assertNotNull(myOwnClassLoaderWeakReference.get());
+        assertFalse(myOwnClassLoaderWeakReference.refersTo(null));
         objectStreamClass_MemoryLeakExample = null;
         myOwnClassLoader = null;
         loadClass = null;
         con = null;
-        assertNotNull(myOwnClassLoaderWeakReference.get());
+        assertFalse(myOwnClassLoaderWeakReference.refersTo(null));
 
-        ForceGC gc = new ForceGC();
-        assertTrue(gc.await(() -> myOwnClassLoaderWeakReference.get() == null));
+        assertTrue(ForceGC.wait(() -> myOwnClassLoaderWeakReference.refersTo(null)));
     }
 }
 

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -152,8 +152,7 @@ public class LoadLibraryUnload {
         clazz = null;
         threads = null;
         exceptions.clear();
-        ForceGC gc = new ForceGC();
-        if (!gc.await(() -> wClass.refersTo(null))) {
+        if (!ForceGC.wait(() -> wClass.refersTo(null))) {
             throw new RuntimeException("Class1 hasn't been GC'ed");
         }
     }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -26,7 +26,8 @@
  * LoadLibraryUnload class calls ClassLoader.loadedLibrary from multiple threads
  */
 /*
- * @test
+ * The driver for this test is LoadLibraryUnloadTest.java.
+ *
  * @bug 8266310
  * @summary Loads a native library from multiple class loaders and multiple
  *          threads. This creates a race for loading the library. The winner
@@ -35,14 +36,12 @@
  *          loaded in a different class loader that won the race. The test
  *          checks that the loaded class is GC'ed, that means the class loader
  *          is GC'ed and the native library is unloaded.
- * @library /test/lib
- * @build LoadLibraryUnload p.Class1
- * @run main/othervm/native -Xcheck:jni LoadLibraryUnload
  */
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
 
 import java.lang.*;
+import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.*;
 import java.lang.ref.WeakReference;
@@ -53,6 +52,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import jdk.test.lib.util.ForceGC;
 
 import p.Class1;
 
@@ -111,14 +112,13 @@ public class LoadLibraryUnload {
         int LOADER_COUNT = 5;
         List<Thread> threads = new ArrayList<>();
         Object[] canary = new Object[LOADER_COUNT];
-        WeakReference<Object> wCanary[] = new WeakReference[LOADER_COUNT];
-        ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
+        final WeakReference<Object> wCanary[] = new WeakReference[LOADER_COUNT];
 
         for (int i = 0 ; i < LOADER_COUNT ; i++) {
             // LOADER_COUNT loaders and 2X threads in total.
             // winner loads the library in 2 threads
             canary[i] = new Object();
-            wCanary[i] = new WeakReference<>(canary[i], refQueue);
+            wCanary[i] = new WeakReference<>(canary[i], null);
 
             Class<?> clazz = new TestLoader().loadClass("p.Class1");
             threads.add(new Thread(new LoadLibraryFromClass(clazz, canary[i])));
@@ -162,15 +162,18 @@ public class LoadLibraryUnload {
         canary = null;
         exceptions.clear();
 
-        // Wait for the canary for each of the libraries to be GC'd
-        // before exiting the test.
-        for (int i = 0; i < LOADER_COUNT; i++) {
-            System.gc();
-            var res = refQueue.remove(Utils.adjustTimeout(5 * 1000L));
-            System.out.println(i + " dequeued: " + res);
-            if (res == null) {
-                Asserts.fail("Too few cleared WeakReferences");
+        // Wait for the canary for each of the libraries to be GC'd (cleared)
+        boolean allClear = ForceGC.wait(() -> {
+            for (int i = 0; i < wCanary.length; i++) {
+                if (!wCanary[i].refersTo(null)) {
+                    return false;
+                }
             }
-        }
+            return true;
+        });
+        Asserts.assertTrue(allClear, "Not all WeakReferences cleared");
+
+        // Ensure the WeakReferences are strongly referenced until they can be dequeued
+        Reference.reachabilityFence(wCanary);
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnload.java
@@ -40,8 +40,10 @@
  * @run main/othervm/native -Xcheck:jni LoadLibraryUnload
  */
 import jdk.test.lib.Asserts;
-import jdk.test.lib.util.ForceGC;
+import jdk.test.lib.Utils;
+
 import java.lang.*;
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.*;
 import java.lang.ref.WeakReference;
 import java.net.URL;
@@ -82,11 +84,13 @@ public class LoadLibraryUnload {
     private static class LoadLibraryFromClass implements Runnable {
         Object object;
         Method method;
+        Object canary;
 
-        public LoadLibraryFromClass(Class<?> fromClass) {
+        public LoadLibraryFromClass(Class<?> fromClass, Object canary) {
             try {
                 this.object = fromClass.newInstance();
-                this.method = fromClass.getDeclaredMethod("loadLibrary");
+                this.method = fromClass.getDeclaredMethod("loadLibrary", Object.class);
+                this.canary = canary;
             } catch (ReflectiveOperationException roe) {
                 throw new RuntimeException(roe);
             }
@@ -95,7 +99,7 @@ public class LoadLibraryUnload {
         @Override
         public void run() {
             try {
-                method.invoke(object);
+                method.invoke(object, canary);
             } catch (ReflectiveOperationException roe) {
                 throw new RuntimeException(roe);
             }
@@ -104,15 +108,21 @@ public class LoadLibraryUnload {
 
     public static void main(String[] args) throws Exception {
 
-        Class<?> clazz = null;
+        int LOADER_COUNT = 5;
         List<Thread> threads = new ArrayList<>();
+        Object[] canary = new Object[LOADER_COUNT];
+        WeakReference<Object> wCanary[] = new WeakReference[LOADER_COUNT];
+        ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
 
-        for (int i = 0 ; i < 5 ; i++) {
-            // 5 loaders and 10 threads in total.
+        for (int i = 0 ; i < LOADER_COUNT ; i++) {
+            // LOADER_COUNT loaders and 2X threads in total.
             // winner loads the library in 2 threads
-            clazz = new TestLoader().loadClass("p.Class1");
-            threads.add(new Thread(new LoadLibraryFromClass(clazz)));
-            threads.add(new Thread(new LoadLibraryFromClass(clazz)));
+            canary[i] = new Object();
+            wCanary[i] = new WeakReference<>(canary[i], refQueue);
+
+            Class<?> clazz = new TestLoader().loadClass("p.Class1");
+            threads.add(new Thread(new LoadLibraryFromClass(clazz, canary[i])));
+            threads.add(new Thread(new LoadLibraryFromClass(clazz, canary[i])));
         }
 
         final Set<Throwable> exceptions = ConcurrentHashMap.newKeySet();
@@ -140,20 +150,27 @@ public class LoadLibraryUnload {
                 .reduce(true, (i, a) -> i && a);
 
         // expect exactly 8 errors
-        Asserts.assertTrue(exceptions.size() == 8,
-                "Expected to see 8 failing threads");
+        int expectedErrorCount = (LOADER_COUNT - 1) * 2;
+        Asserts.assertTrue(exceptions.size() == expectedErrorCount,
+                "Expected to see " + expectedErrorCount + " failing threads");
 
         Asserts.assertTrue(allAreUnsatisfiedLinkError,
                 "All errors have to be UnsatisfiedLinkError");
 
-        WeakReference<Class<?>> wClass = new WeakReference<>(clazz);
-
         // release strong refs
-        clazz = null;
         threads = null;
+        canary = null;
         exceptions.clear();
-        if (!ForceGC.wait(() -> wClass.refersTo(null))) {
-            throw new RuntimeException("Class1 hasn't been GC'ed");
+
+        // Wait for the canary for each of the libraries to be GC'd
+        // before exiting the test.
+        for (int i = 0; i < LOADER_COUNT; i++) {
+            System.gc();
+            var res = refQueue.remove(Utils.adjustTimeout(5 * 1000L));
+            System.out.println(i + " dequeued: " + res);
+            if (res == null) {
+                Asserts.fail("Too few cleared WeakReferences");
+            }
         }
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -28,18 +28,18 @@
  */
 /*
  * @test
- * @bug 8266310 8289919
+ * @bug 8266310 8289919 8293282
  * @summary Checks that JNI_OnLoad is invoked only once when multiple threads
  *          call System.loadLibrary concurrently, and JNI_OnUnload is invoked
  *          when the native library is loaded from a custom class loader.
  * @library /test/lib
  * @build LoadLibraryUnload p.Class1
- * @run main/othervm/native -Xcheck:jni LoadLibraryUnloadTest
+ * @run main/othervm/native LoadLibraryUnloadTest
  */
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.JDKToolFinder;
-import jdk.test.lib.process.*;
+import jdk.test.lib.process.OutputAnalyzer;
 
 import java.lang.ProcessBuilder;
 import java.lang.Process;
@@ -50,7 +50,6 @@ public class LoadLibraryUnloadTest {
 
     private static String testClassPath = System.getProperty("test.classes");
     private static String testLibraryPath = System.getProperty("test.nativepath");
-    private static String classPathSeparator = System.getProperty("path.separator");
 
     private static Process runJavaCommand(String... command) throws Throwable {
         String java = JDKToolFinder.getJDKTool("java");

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,7 @@
  */
 /*
  * @test
- * @bug 8266310
+ * @bug 8266310 8289919
  * @summary Checks that JNI_OnLoad is invoked only once when multiple threads
  *          call System.loadLibrary concurrently, and JNI_OnUnload is invoked
  *          when the native library is loaded from a custom class loader.
@@ -102,5 +102,8 @@ public class LoadLibraryUnloadTest {
         Asserts.assertTrue(
                 countLines(outputAnalyzer, "Native library unloaded.") == refCount,
                 "Failed to unload native library");
+
+        Asserts.assertEquals(0, outputAnalyzer.getExitValue(),
+                "LoadLibraryUnload exit value not zero");
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryUnload/p/Class1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,8 +33,18 @@ public class Class1 {
     }
 
     // method called from java threads
-    public void loadLibrary() throws Exception {
+    public void loadLibrary(Object obj) throws Exception {
         System.loadLibrary("loadLibraryUnload");
         System.out.println("Native library loaded from Class1.");
+        synchronized (Class1.class) {
+            setRef(obj);
+        }
     }
+
+    /**
+     * Native method to store an object ref in a native Global reference
+     * to be cleared when the library is unloaded.
+     * @param obj an object
+     */
+    private static native void setRef(Object obj);
 }

--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,9 +66,8 @@ public class NativeLibraryTest {
             // Unload the class loader and native library, and give the Cleaner
             // thread a chance to unload the native library.
             // unloadedCount is incremented when the native library is unloaded.
-            ForceGC gc = new ForceGC();
             final int finalCount = count;
-            if (!gc.await(() -> finalCount == unloadedCount)) {
+            if (!ForceGC.wait(() -> finalCount == unloadedCount)) {
                 throw new RuntimeException("Expected unloaded=" + count +
                     " but got=" + unloadedCount);
             }

--- a/test/jdk/java/lang/invoke/defineHiddenClass/UnloadingTest.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/UnloadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,18 +214,15 @@ public class UnloadingTest {
         }
 
         void unload() {
-            // Force garbage collection to trigger unloading of class loader and native library
-            ForceGC gc = new ForceGC();
-            assertTrue(gc.await(() -> weakRef.get() == null));
-
-            if (weakRef.get() != null) {
+            // Force garbage collection to trigger unloading of class loader
+            // and native library.
+            if (!ForceGC.wait(() -> weakRef.refersTo(null))) {
                 throw new RuntimeException("loader " + " not unloaded!");
             }
         }
 
         boolean tryUnload() {
-            ForceGC gc = new ForceGC();
-            return gc.await(() -> weakRef.get() == null);
+            return ForceGC.wait(() -> weakRef.refersTo(null));
         }
     }
 

--- a/test/jdk/java/lang/reflect/callerCache/ReflectionCallerCacheTest.java
+++ b/test/jdk/java/lang/reflect/callerCache/ReflectionCallerCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,9 +107,7 @@ public class ReflectionCallerCacheTest {
         WeakReference<?> weakLoader = loadAndRunClass(classname);
 
         // Force garbage collection to trigger unloading of class loader
-        new ForceGC().await(() -> weakLoader.get() == null);
-
-        if (weakLoader.get() != null) {
+        if (!ForceGC.wait(() -> weakLoader.refersTo(null))) {
             throw new RuntimeException("Class " + classname + " not unloaded!");
         }
     }

--- a/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -49,8 +49,7 @@ public final class CheckCleanerBound {
         // Check if the object has been collected.  The collection will not
         // happen if the cleaner implementation in PasswordCallback is bound
         // to the PasswordCallback object.
-        ForceGC gc = new ForceGC();
-        if (!gc.await(() -> weakRef.get() == null)) {
+        if (!ForceGC.wait(() -> weakRef.refersTo(null))) {
             throw new RuntimeException(
                 "PasswordCallback object is not released");
         }

--- a/test/jdk/sun/security/jgss/GssContextCleanup.java
+++ b/test/jdk/sun/security/jgss/GssContextCleanup.java
@@ -54,8 +54,7 @@ public final class GssContextCleanup {
         context = null;
 
         // Check if the object has been collected.
-        ForceGC gc = new ForceGC();
-        if (!gc.await(() -> weakRef.get() == null)) {
+        if (!ForceGC.wait(() -> weakRef.refersTo(null))) {
             throw new RuntimeException("GSSContext object is not released");
         }
     }

--- a/test/jdk/sun/security/jgss/GssNameCleanup.java
+++ b/test/jdk/sun/security/jgss/GssNameCleanup.java
@@ -55,8 +55,7 @@ public final class GssNameCleanup {
             name = null;
 
             // Check if the object has been collected.
-            ForceGC gc = new ForceGC();
-            if (!gc.await(() -> weakRef.get() == null)) {
+            if (!ForceGC.wait(() -> weakRef.refersTo(null))) {
                 throw new RuntimeException("GSSName object is not released");
             }
         } catch (GSSException gsse) {

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
@@ -89,10 +89,8 @@ public class MultipleLogins {
             Security.removeProvider(providers[i].getName());
             providers[i] = null;
 
-            ForceGC gc = new ForceGC();
             int finalI = i;
-            gc.await(() -> weakRef[finalI].get() == null);
-            if (!weakRef[i].refersTo(null)) {
+            if (!ForceGC.wait(() -> weakRef[finalI].refersTo(null))) {
                 throw new RuntimeException("Expected SunPKCS11 Provider to be GC'ed..");
             }
         }

--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -23,68 +23,56 @@
 
 package jdk.test.lib.util;
 
-import java.lang.ref.Cleaner;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.util.function.BooleanSupplier;
 
 /**
  * Utility class to invoke System.gc()
  */
 public class ForceGC {
-    private final static Cleaner cleaner = Cleaner.create();
-
-    private final CountDownLatch cleanerInvoked;
-    private Object o;
-    private int gcCount = 0;
-
-    public ForceGC() {
-        this.o = new Object();
-        this.cleanerInvoked = new CountDownLatch(1);
-        cleaner.register(o, cleanerInvoked::countDown);
-    }
-
-    private void doit(int iter) {
-        try {
-            for (int i = 0; i < 10; i++) {
-                System.gc();
-                gcCount++;
-                if (cleanerInvoked.await(100L, TimeUnit.MILLISECONDS)) {
-                    return;
-                }
-            }
-        } catch (InterruptedException unexpected) {
-            throw new AssertionError("unexpected InterruptedException");
-        }
-    }
+    // The jtreg testing timeout factor.
+    private static final double TIMEOUT_FACTOR = Double.valueOf(
+            System.getProperty("test.timeout.factor", "1.0"));
 
     /**
-     * Causes the current thread to wait until the {@code BooleanSupplier} returns true,
-     * unless the thread is interrupted or a predefined waiting time elapses.
+     * Causes the current thread to wait until the {@code booleanSupplier}
+     * returns true, or a specific waiting time elapses.  The waiting time
+     * is 1 second scaled with the jtreg testing timeout factor.
      *
-     * @param s boolean supplier
-     * @return true if the {@code BooleanSupplier} returns true and false if
-     *         the predefined waiting time elapsed before the count reaches zero.
-     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @param booleanSupplier boolean supplier
+     * @return true if the {@code booleanSupplier} returns true, or false
+     *     if did not complete after the specific waiting time.
      */
-    public boolean await(BooleanSupplier s) {
-        o = null; // Keep reference to Object until now, to ensure the Cleaner
-                  // doesn't count down the latch before await() is called.
-        for (int i = 0; i < 10; i++) {
-            if (s.getAsBoolean()) {
-                System.out.println("ForceGC condition met after System.gc() " + gcCount + " times");
+    public static boolean wait(BooleanSupplier booleanSupplier) {
+        ReferenceQueue<Object> queue = new ReferenceQueue<>();
+        Object obj = new Object();
+        PhantomReference<Object> ref = new PhantomReference<>(obj, queue);
+        obj = null;
+        Reference.reachabilityFence(obj);
+        Reference.reachabilityFence(ref);
+
+        int retries = (int)(Math.round(1000L * TIMEOUT_FACTOR) / 200);
+        for (; retries >= 0; retries--) {
+            if (booleanSupplier.getAsBoolean()) {
                 return true;
             }
 
-            doit(i);
+            System.gc();
+
             try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                throw new AssertionError("unexpected interrupted sleep", e);
+                // The remove() will always block for the specified milliseconds
+                // if the reference has already been removed from the queue.
+                // But it is fine.  For most cases, the 1st GC is sufficient
+                // to trigger and complete the cleanup.
+                queue.remove(200L);
+            } catch (InterruptedException ie) {
+                // ignore, the loop will try again
             }
         }
 
-        System.out.println("ForceGC condition not met after System.gc() " + gcCount + " times");
-        return false;
+        return booleanSupplier.getAsBoolean();
     }
 }
+


### PR DESCRIPTION
The two commits are being backported from JDK-next.

See [LoadLibraryUnloadTest's commit history in JDK-next](https://github.com/ibmruntimes/openj9-openjdk-jdk/commits/openj9/test/jdk/java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java).

1. The first commit is required to support the second and third commits: https://bugs.openjdk.org/browse/JDK-8287596.
2. The second commit should fix https://github.com/eclipse-openj9/openj9/issues/16337.
3. The third commit should prevent the issue described in https://bugs.openjdk.org/browse/JDK-8293282.

Closes https://github.com/eclipse-openj9/openj9/issues/16337

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>