### PR TITLE
Use GetExtensionEvents to derive extension event numbers

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/BreakpointInYieldTest/libBreakpointInYieldTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/BreakpointInYieldTest/libBreakpointInYieldTest.cpp
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <string.h>
 #include "jvmti.h"
@@ -250,13 +255,13 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadMount", NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
     return JNI_ERR;
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadUnmount", NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
     return JNI_ERR;
@@ -303,10 +308,10 @@ Java_BreakpointInYieldTest_check(JNIEnv *jni, jclass cls) {
   err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_VIRTUAL_THREAD_START, NULL);
   check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: disable VIRTUAL_THREAD_START");
 
-  err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_DISABLE, "VirtualThreadMount", NULL);
   check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: disable VIRTUAL_THREAD_MOUNT");
 
-  err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_DISABLE, "VirtualThreadUnmount", NULL);
   check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: disable VIRTUAL_THREAD_UNMOUNT");
 
   err = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_BREAKPOINT, NULL);

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/MethodExitTest/libMethodExitTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/MethodExitTest/libMethodExitTest.cpp
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <string.h>
 #include "jvmti.h"
@@ -215,12 +220,14 @@ breakpoint_hit2(jvmtiEnv *jvmti, JNIEnv* jni,
   // Enable VIRTUAL_THREAD_MOUNT events on the vthread.
   LOG("Hit #2: Breakpoint: %s: enabling VirtualThreadMount events on %s thread: %p\n",
           mname, is_virtual ? "virtual" : "carrier", (void*)thread);
-  set_event_notification_mode(jvmti, jni, JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, thread);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadMount", thread);
+  check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: enable VIRTUAL_THREAD_MOUNT");
 
   // Enable VIRTUAL_THREAD_UNMOUNT events on the vthread.
   LOG("Hit #2: Breakpoint: %s: enabling VirtualThreadUnmount events on %s thread: %p\n",
           mname, is_virtual ? "virtual" : "carrier", (void*)thread);
-  set_event_notification_mode(jvmti, jni, JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, thread);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadUnmount", thread);
+  check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: enable VIRTUAL_THREAD_UNMOUNT");
 
   // Test GetThreadLocalStorage for virtual thread.
   LOG("Hit #2: Breakpoint: %s: checking GetThreadLocalStorage on virtual thread: %p\n",
@@ -264,11 +271,13 @@ breakpoint_hit3(jvmtiEnv *jvmti, JNIEnv* jni,
 
   // Disable VIRTUAL_THREAD_MOUNT events on the vthread.
   LOG("Hit #3: Breakpoint: %s: disabling VirtualThreadMount events on virtual thread: %p\n", mname, (void*)thread);
-  set_event_notification_mode(jvmti, jni, JVMTI_DISABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, thread);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_DISABLE, "VirtualThreadMount", thread);
+  check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: disable VIRTUAL_THREAD_MOUNT");
 
   // Disable VIRTUAL_THREAD_UNMOUNT events on the vthread.
   LOG("Hit #3: Breakpoint: %s: disabling VirtualThreadUnmount events on virtual thread: %p\n", mname, (void*)thread);
-  set_event_notification_mode(jvmti, jni, JVMTI_DISABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, thread);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_DISABLE, "VirtualThreadUnmount", thread);
+  check_jvmti_status(jni, err, "check: error in JVMTI SetEventNotificationMode: disable VIRTUAL_THREAD_UNMOUNT");
 }
 
 static void JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/NullAsCurrentThreadTest/libNullAsCurrentThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/NullAsCurrentThreadTest/libNullAsCurrentThreadTest.cpp
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <string.h>
 #include "jvmti.h"
@@ -395,7 +400,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     if (err != JVMTI_ERROR_NONE) {
       LOG("Agent_OnLoad: error in JVMTI SetEventCallbacks: %d\n", err);
     }
-    err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
+    err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadMount", NULL);
     if (err != JVMTI_ERROR_NONE) {
       LOG("Agent_OnLoad: error in JVMTI SetEventNotificationMode: %d\n", err);
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <string.h>
 #include "jvmti.h"
@@ -616,13 +621,13 @@ Agent_OnLoad(JavaVM *jvm, char *options,
     return JNI_ERR;
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadMount", NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
     return JNI_ERR;
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_UNMOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadUnmount", NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
     return JNI_ERR;

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadUnsupportedTest/libVThreadUnsupportedTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadUnsupportedTest/libVThreadUnsupportedTest.cpp
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <string.h>
 #include <atomic>
@@ -187,7 +192,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     return JNI_ERR;
   }
 
-  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, EXT_EVENT_VIRTUAL_THREAD_MOUNT, NULL);
+  err = set_ext_event_notification_mode(jvmti, JVMTI_ENABLE, "VirtualThreadMount", NULL);
   if (err != JVMTI_ERROR_NONE) {
     LOG("error in JVMTI SetEventNotificationMode: %d\n", err);
     return JNI_ERR;

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.h
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.h
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JVMTI_COMMON_H
 #define JVMTI_COMMON_H
@@ -728,10 +733,6 @@ jthread find_thread_by_name(jvmtiEnv* jvmti, JNIEnv* jni, const char name[]) {
 /*
  * JVMTI Extension Mechanism
  */
-static const jvmtiEvent
-  EXT_EVENT_VIRTUAL_THREAD_MOUNT   = (jvmtiEvent)((int)JVMTI_MIN_EVENT_TYPE_VAL - 2),
-  EXT_EVENT_VIRTUAL_THREAD_UNMOUNT = (jvmtiEvent)((int)JVMTI_MIN_EVENT_TYPE_VAL - 3);
-
 static jvmtiExtensionFunction
 find_ext_function(jvmtiEnv* jvmti, JNIEnv* jni, const char* fname) {
   jint extCount = 0;
@@ -827,6 +828,16 @@ static void
 set_event_notification_mode(jvmtiEnv* jvmti, JNIEnv* jni, jvmtiEventMode mode, jvmtiEvent event_type, jthread event_thread) {
   jvmtiError err = jvmti->SetEventNotificationMode(mode, event_type, event_thread);
   check_jvmti_status(jni, err, "jvmti_common set_event_notification_mode: Error in JVMTI SetEventNotificationMode");
+}
+
+static jvmtiError
+set_ext_event_notification_mode(jvmtiEnv* jvmti, jvmtiEventMode mode, const char* ename, jthread event_thread) {
+  jvmtiExtensionEventInfo* info = find_ext_event(jvmti, ename);
+  if (NULL == info) {
+    LOG("jvmti_common set_ext_event_notification_mode: Extension event was not found: %s\n", ename);
+    return JVMTI_ERROR_NOT_AVAILABLE;
+  }
+  return jvmti->SetEventNotificationMode(mode, (jvmtiEvent)info->extension_event_index, event_thread);
 }
 
 int


### PR DESCRIPTION
Currently, extension event numbers are hard-coded in the tests. This is
invalid since the extension event numbers can vary between
implementations. Instead, GetExtensionEvents should be used to derive
the extension event numbers.

Related: https://github.com/eclipse-openj9/openj9/pull/16501
Related: https://github.com/eclipse-openj9/openj9/issues/16167

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>