### PR TITLE
[FFI]Inline the missing libc functions for symbol lookup on AIX

### DIFF
--- a/closed/src/java.base/aix/native/libsyslookup/syslookup.c
+++ b/closed/src/java.base/aix/native/libsyslookup/syslookup.c
@@ -1,0 +1,37 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+#include <fstab.h>
+#include <setjmp.h>
+#include <string.h>
+#include <strings.h>
+
+/* The function list inlines the libc functions which
+ * are missing in loading the default library.
+ */
+__attribute__((visibility("default"))) void* funcs[] = {
+		&bcopy, &endfsent, &getfsent, &getfsfile, &getfsspec, &longjmp,
+		&memcpy, &memmove, &setfsent, &setjmp, &siglongjmp, &strcat,
+		&strcpy, &strncat, &strncpy
+};


### PR DESCRIPTION
The changes aim to support the symbol lookup via FFI for
the missing libc functions in loading the default library on
AIX by inlining their address into a function list in native to
ensure they are correctly invoked with the native address
fetched in the FFI code.

Fixes: #eclipse-openj9/openj9/issues/16386

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
