### PR TITLE
Backport missing Oracle CPE from the head stream

### DIFF
--- a/make/data/autoheaders/assemblyprefix.h
+++ b/make/data/autoheaders/assemblyprefix.h
@@ -4,7 +4,9 @@
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/java.base/share/native/libjava/Continuation.c
+++ b/src/java.base/share/native/libjava/Continuation.c
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
The files are missing the Oracle "Classpath" exception in jdk19 but are otherwise identical to the head stream.

OpenJDK will not fix this for jdk19 because there won't be any more releases of this stream.