### PR TITLE
(0.37) Initialize Continuation.vthread in constructor

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 package java.lang;
@@ -177,6 +177,7 @@ final class VirtualThread extends BaseVirtualThread {
     private static class VThreadContinuation extends Continuation {
         VThreadContinuation(VirtualThread vthread, Runnable task) {
             super(VTHREAD_SCOPE, () -> vthread.run(task));
+            this.vthread = vthread;
         }
         @Override
         protected void onPinned(Continuation.Pinned reason) {


### PR DESCRIPTION
Mutual dependency: https://github.com/eclipse-openj9/openj9/pull/17094

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/83