### PR TITLE
(0.37) Increase default heap size for Skynet to 768MB

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/Skynet.java
@@ -20,13 +20,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 /**
  * @test
  * @summary Stress test virtual threads with a variation of the Skynet 1M benchmark
  * @requires vm.continuations
  * @compile --enable-preview -source ${jdk.version} Skynet.java
- * @run main/othervm/timeout=300 --enable-preview Skynet
+ * @run main/othervm/timeout=300 --enable-preview -Xmx768m Skynet
  */
 
 /**


### PR DESCRIPTION
Time out and OutOfMemoryError seen during Skynet test run, increasing the default memory to avoid such failure.

Related issue https://github.com/eclipse-openj9/openj9/issues/16728

Cherry pick https://github.com/ibmruntimes/openj9-openjdk-jdk19/pull/91 for the 0.37 release.